### PR TITLE
Change Error too Warning

### DIFF
--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -273,19 +273,21 @@ export class RattaRLEDecoder {
 		let newColor =
 			encodedColor === -1 ? Color('transparent') : translation[encodedColor];
 		let chunk: Uint8Array;
+
 		if (newColor === undefined) {
-			throw Error(`unknown color 0x${encodedColor.toString(16)}`);
-		}
-		if (newColor.alpha() === 0) {
-			chunk = Uint8Array.from(new Uint8Array([0, 0, 0, 0]));
-		} else {
-			chunk = Uint8Array.from(
-				new Uint8Array([...newColor.rgb().array(), ~~(255 * newColor.alpha())]),
-			);
-		}
-		for (let index = 0; index < length; index++) {
-			chunks.push(chunk);
-		}
+            // throw Error(`unknown color 0x${encodedColor.toString(16)}`);
+			console.warn(`Unknown Color 0x${encodedColor.toString(16)}`)
+            chunk = Uint8Array.from(new Uint8Array([255, 255, 255, 0]));
+        }else{
+            if (newColor.alpha() === 0) {
+                chunk = Uint8Array.from(new Uint8Array([0, 0, 0, 0]));
+            } else {	
+                chunk = Uint8Array.from(new Uint8Array([...newColor.rgb().array(), ~~(255 * newColor.alpha())]));
+            }
+        }
+        for (let index = 0; index < length; index++) {
+            chunks.push(chunk);
+        }
 		return chunks;
 	}
 


### PR DESCRIPTION
The Original Error is mentioned here: https://github.com/philips/supernote-obsidian-plugin/issues/29

The Conversion of the File, Errors out when adding a different Template in the Background of the Supernote File.

Just Removed the Error Thrown. This Renders the Supernote File, as expected, with no Side Effects for me.
Unfortunately, I don't have a deeper Understanding of the File Structure used by Ratta or the Code Provided here.

In my understanding, the Original Error Thrown, just seems to mean that a Color is Undefined. 
On trying to understand what is missing from the Image, I tried adding it in Random Colors to the Image (Currently set too Transparent) to see what is missing. 
I couldn't Identify something, as it did not render something.
At this point, I'm clueless, at what these Colors could mean in the Context of the Supernote File without having more Information about it.

If somebody could provide more Information, this would be nice.

The PR fixes the Problem for me. 