### PR TITLE
Fix paragraph-extraction bounding-box bug for multi-line blocks

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,3 @@
-export { SupernoteX } from './parsing';
+export { SupernoteX, extractText, extractParagraphs } from './parsing';
 export { toImage } from './conversion';
 export { fetchMirrorFrame } from './mirror';

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -189,6 +189,171 @@ function uint8ArrayToString(
 // Note: known vertical orientations are 1000, 1180
 const HORIZONTAL_ORIENTATIONS = ['1090', '1270'];
 
+type IRecognitionWord = IRecognitionElement['words'][number];
+
+interface IRecognizedLine {
+	text: string;
+	/** Left edge of the line's bounding box. */
+	x: number;
+	/** Top edge of the line's bounding box. */
+	top: number;
+	/** Bottom edge of the line's bounding box. */
+	bottom: number;
+	height: number;
+}
+
+/** How much two fragments' tops may differ, relative to their own height,
+ * and still be considered the same visual line. */
+const SAME_LINE_HEIGHT_RATIO = 0.5;
+/** How large a gap between lines must be, relative to the local line
+ * height, to be treated as a paragraph break rather than a line wrap. */
+const PARAGRAPH_GAP_HEIGHT_RATIO = 1.0;
+/** Number of preceding lines averaged to estimate the "local" line height,
+ * so a page mixing large headings and small body text doesn't skew a
+ * single page-wide average. */
+const LINE_HEIGHT_WINDOW = 3;
+
+/** Recognition labels arrive as UTF-8 bytes read through a Latin-1 decoder,
+ * so they need to be re-decoded to recover the original text. */
+function decodeRecognitionLabel(label: string): string {
+	return decodeURIComponent(escape(label));
+}
+
+/** Split one recognition element into its visual lines. Multi-line
+ * elements embed "\n" marker words between lines; each line gets its own
+ * bounding box computed from its own words, rather than borrowing the
+ * bounding box of the element's first word. */
+function splitElementIntoLines(element: IRecognitionElement): IRecognizedLine[] {
+	const text = decodeRecognitionLabel(element.label);
+	const lineTexts = text.split('\n');
+
+	const wordLines: IRecognitionWord[][] = [[]];
+	for (const word of element.words) {
+		if (word.label === '\n' && !word['bounding-box']) {
+			wordLines.push([]);
+		} else {
+			wordLines[wordLines.length - 1].push(word);
+		}
+	}
+
+	// Defensive fallback: if the "\n" markers didn't line up with the
+	// label's own line breaks, treat the whole element as a single line
+	// rather than silently dropping text.
+	if (wordLines.length !== lineTexts.length) {
+		return boxLine(text.replace(/\n/g, ' ').trim(), element.words);
+	}
+
+	return lineTexts.flatMap((lineText, i) => boxLine(lineText.trim(), wordLines[i]));
+}
+
+/** Build a single IRecognizedLine (if any word has a bounding box) for the
+ * given text and words. */
+function boxLine(text: string, words: IRecognitionWord[]): IRecognizedLine[] {
+	if (text.length === 0) return [];
+
+	const boxes = words
+		.map((w) => w['bounding-box'])
+		.filter((b): b is NonNullable<IRecognitionWord['bounding-box']> => !!b);
+
+	if (boxes.length === 0) return [];
+
+	const top = Math.min(...boxes.map((b) => b.y));
+	const bottom = Math.max(...boxes.map((b) => b.y + b.height));
+	const x = Math.min(...boxes.map((b) => b.x));
+
+	return [{ text, x, top, bottom, height: bottom - top }];
+}
+
+/** Merge line fragments that sit on the same visual line (this happens
+ * when the recognizer splits one handwritten line across several
+ * elements) via a single forward sweep, chaining each fragment to the
+ * previous one rather than comparing every pair. A pairwise "close in y"
+ * comparator is not guaranteed transitive and can produce inconsistent
+ * sort orders; this sweep sidesteps that. */
+function clusterIntoVisualLines(lines: IRecognizedLine[]): IRecognizedLine[] {
+	if (lines.length === 0) return [];
+
+	const sorted = [...lines].sort((a, b) => a.top - b.top);
+
+	const clusters: IRecognizedLine[][] = [[sorted[0]]];
+	for (let i = 1; i < sorted.length; i++) {
+		const line = sorted[i];
+		const cluster = clusters[clusters.length - 1];
+		const last = cluster[cluster.length - 1];
+		const sameLineThreshold = Math.min(last.height, line.height) * SAME_LINE_HEIGHT_RATIO;
+
+		if (line.top - last.top < sameLineThreshold) {
+			cluster.push(line);
+		} else {
+			clusters.push([line]);
+		}
+	}
+
+	return clusters.map((cluster) => {
+		cluster.sort((a, b) => a.x - b.x);
+		return {
+			text: cluster.map((l) => l.text).join(' '),
+			x: Math.min(...cluster.map((l) => l.x)),
+			top: Math.min(...cluster.map((l) => l.top)),
+			bottom: Math.max(...cluster.map((l) => l.bottom)),
+			height: Math.max(...cluster.map((l) => l.bottom)) - Math.min(...cluster.map((l) => l.top)),
+		};
+	});
+}
+
+/** Join visual lines into paragraphs. A gap is measured from the bottom of
+ * the previous line to the top of the next, so a wrapped line inside a
+ * tall multi-line block doesn't get mistaken for a paragraph break just
+ * because the block itself spans several lines. The threshold is a local,
+ * rolling estimate of line height rather than a single page-wide average,
+ * so headings and body text don't skew each other's thresholds. */
+function joinLinesIntoParagraphs(lines: IRecognizedLine[]): string {
+	if (lines.length === 0) return '';
+
+	const sorted = [...lines].sort((a, b) => a.top - b.top);
+
+	let result = sorted[0].text;
+	const recentHeights = [sorted[0].height];
+
+	for (let i = 1; i < sorted.length; i++) {
+		const previous = sorted[i - 1];
+		const current = sorted[i];
+		const gap = current.top - previous.bottom;
+
+		const localLineHeight = recentHeights.reduce((sum, h) => sum + h, 0) / recentHeights.length;
+		const isNewParagraph = gap > localLineHeight * PARAGRAPH_GAP_HEIGHT_RATIO;
+
+		result += isNewParagraph ? '\n\n' : ' ';
+		result += current.text;
+
+		recentHeights.push(current.height);
+		if (recentHeights.length > LINE_HEIGHT_WINDOW) recentHeights.shift();
+	}
+
+	return result;
+}
+
+/** Extract plain recognized text, one recognition element per line. */
+export function extractText(elements: IRecognitionElement[]): string {
+	return elements
+		.filter((e) => e.type === 'Text')
+		.map((e) => decodeRecognitionLabel(e.label))
+		.join('\n');
+}
+
+/** Extract recognized text grouped into paragraphs. Wrapped lines within a
+ * paragraph are reflowed onto one line; a vertical gap of roughly a line
+ * height or more is treated as a paragraph break. */
+export function extractParagraphs(elements: IRecognitionElement[]): string {
+	const lines = elements
+		.filter((e) => e.type === 'Text')
+		.flatMap(splitElementIntoLines);
+
+	const visualLines = clusterIntoVisualLines(lines);
+
+	return joinLinesIntoParagraphs(visualLines);
+}
+
 /** Supernote X series note. */
 export class SupernoteX implements ISupernote {
 	declare pageWidth: number;
@@ -375,67 +540,11 @@ export class SupernoteX implements ISupernote {
 	}
 
 	_extractText(elements: IRecognitionElement[]) {
-		const labels = elements
-			.filter((e) => e.type === 'Text')
-			.map((e) => decodeURIComponent(escape(e.label))); // Decode using windows-1254 encoding
-
-		return labels.join("\n");
+		return extractText(elements);
 	}
 
 	_extractParagraphs(elements: IRecognitionElement[]) {
-		// Filter text elements and get their bounding boxes
-		const textElements = elements
-			.filter(e => e.type === 'Text')
-			.map(e => ({
-				text: decodeURIComponent(escape(e.label)),
-				box: e.words[0]?.['bounding-box']
-			}))
-			.filter(e => e.box); // Only keep elements with valid bounding boxes
-
-		if (textElements.length === 0) return '';
-
-		const avgLineHeight = textElements.reduce((sum, e) => sum + (e.box?.height || 0), 0) / textElements.length;
-
-		// Sort by vertical position first, then horizontal
-		textElements.sort((a, b) => {
-			const verticalDiff = (a.box?.y || 0) - (b.box?.y || 0);
-			// If elements are roughly on the same line (within 0.5 line height), sort by x
-			if (Math.abs(verticalDiff) < avgLineHeight * 0.5) {
-				return (a.box?.x || 0) - (b.box?.x || 0);
-			}
-			return verticalDiff;
-		});
-
-		// Group elements into paragraphs based on vertical spacing
-		let result = '';
-		let lastY = textElements[0].box?.y || 0;
-		let lastX = textElements[0].box?.x || 0;
-
-		textElements.forEach((element, index) => {
-			const currentY = element.box?.y || 0;
-			const currentX = element.box?.x || 0;
-
-			if (index > 0) {
-				const verticalGap = currentY - lastY;
-				const isNewParagraph = verticalGap > avgLineHeight * 1.5;
-
-				if (isNewParagraph) {
-					result += '\n\n';
-				} else if (currentX < lastX) { // Same paragraph
-					result += ' ';
-				} else { // Same line
-					result += ' ';
-				}
-			}
-
-
-			const trimmed = element.text.replace(/\n/g, ' ');
-			result += trimmed;
-			lastY = currentY;
-			lastX = currentX;
-		});
-
-		return result;
+		return extractParagraphs(elements);
 	}
 
 	/** Parse layer at a specific address in a Supernote file's buffer contents. */

--- a/tests/main.test.ts
+++ b/tests/main.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs-extra"
 import { toImage } from "../src/conversion"
-import { SupernoteX } from "../src/parsing"
+import { SupernoteX, extractParagraphs } from "../src/parsing"
+import { IRecognitionElement } from "../src/format"
 import * as imagejs from "image-js"
 import { describe, test, expect } from 'vitest'
 
@@ -174,6 +175,59 @@ describe("rtr", () => {
     ].join('\n')
 
     expect(sn.pages[0].text).toEqual(et)
+  })
+})
+
+describe("extractParagraphs", () => {
+  // Helper to build a recognition word: a positioned word, or (with no box)
+  // one of the recognizer's own "\n" line-break markers.
+  function word(label: string, x?: number, y?: number, w?: number, h?: number): IRecognitionElement['words'][number] {
+    if (x === undefined) return { label }
+    return { label, 'bounding-box': { x, y: y as number, width: w as number, height: h as number } }
+  }
+
+  test("does not insert a paragraph break after a wrapped multi-line block with no blank line before the next block", () => {
+    // Element A: one recognition block spanning two wrapped lines, like a
+    // real handwritten paragraph the device recognized as a single block.
+    const elementA: IRecognitionElement = {
+      type: 'Text',
+      label: 'alpha bravo charlie\ndelta echo foxtrot',
+      words: [
+        word('alpha', 0, 0, 20, 10), word(' '),
+        word('bravo', 25, 0, 20, 10), word(' '),
+        word('charlie', 50, 0, 25, 10),
+        word('\n'),
+        word('delta', 0, 9, 20, 10), word(' '),
+        word('echo', 25, 9, 20, 10), word(' '),
+        word('foxtrot', 50, 9, 25, 10),
+      ],
+    }
+
+    // Element B: a separate block immediately below element A's last line
+    // (gap of 2, well under one line height) - the device split it into a
+    // new block, but visually it's the same paragraph continuing.
+    const elementB: IRecognitionElement = {
+      type: 'Text',
+      label: 'golf hotel',
+      words: [
+        word('golf', 0, 21, 20, 10), word(' '),
+        word('hotel', 25, 21, 20, 10),
+      ],
+    }
+
+    // Element C: a genuinely new paragraph, separated by a real blank gap.
+    const elementC: IRecognitionElement = {
+      type: 'Text',
+      label: 'india',
+      words: [word('india', 0, 60, 20, 10)],
+    }
+
+    const result = extractParagraphs([elementA, elementB, elementC])
+
+    expect(result).toEqual([
+      'alpha bravo charlie delta echo foxtrot golf hotel',
+      'india',
+    ].join('\n\n'))
   })
 })
 


### PR DESCRIPTION
## Summary
- `_extractParagraphs` measured paragraph gaps using only the first word's bounding box for an entire recognition element, so a multi-line block's own height was ignored and gaps were measured top-to-top instead of bottom-to-top. This works when the following gap happens to be large, but silently misfires (spurious paragraph breaks) whenever a multi-line block is immediately followed by another block with no blank line — a case not previously covered by any test.
- Replaces the pairwise "close in y → sort by x" comparator (not guaranteed transitive; can yield inconsistent sort orders) with a single forward-sweep clustering pass over flattened per-line fragments.
- Switches the paragraph-break threshold from one page-wide average line height to a local rolling estimate, so headings and body text on the same page don't skew each other's thresholds.
- Extracts `extractText`/`extractParagraphs` as standalone, independently testable functions in `src/parsing.ts` (also exported from `src/index.ts`); `SupernoteX` methods now delegate to them.
- All constants against `tests/input/rtr.note`'s real recognition data (verified by hand): within-paragraph line-wrap gaps come out negative (bounding boxes overlap due to ascenders/descenders), while real paragraph gaps are 1.35–2.24× the local line height, so a 1.0× threshold cleanly separates the two with margin.

## Test plan
- [x] `npx tsc --noEmit`
- [x] `npx eslint src/parsing.ts tests/main.test.ts`
- [x] `npx vitest run` — 15/15 passing, including the existing `rtr.note` paragraph test (unchanged expected output) and a new regression test exercising a multi-line block immediately followed by another block with no blank line (the case the old top-referenced gap measurement got wrong).