### PR TITLE
Split toPdf() for worker-parallel page rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,36 @@ The default font (Helvetica) only supports Latin text. Pass `fontBytes` with a U
 const pdfBytes = await toPdf(note, { fontBytes: await fs.readFile('NotoSans-Regular.ttf') });
 ```
 
+#### Rendering pages in parallel across Workers
+
+`toPdf` is a convenience wrapper around three lower-level pieces, exported so applications can render pages in parallel (across Web Workers or Node `worker_threads`) instead of one at a time on the main thread:
+
+- `extractPageRenderData(note, pageNumber)` — pulls out the minimal, structured-clone-safe slice of one page needed to render it, safe to `postMessage` to a Worker.
+- `toImage` and `encodePng` (from `image-js`) — both safe to call inside a Worker; render the page and encode it to PNG bytes there.
+- `createPdfContext(options?)` / `addPdfPage(ctx, page, image, options?)` — must run on the main thread (they hold `pdf-lib` objects, which aren't structured-clone-safe); `addPdfPage` accepts either an `Image` or already-encoded PNG bytes, so it can take a Worker's output directly.
+
+```ts
+import { SupernoteX, extractPageRenderData, createPdfContext, addPdfPage } from 'supernote-typescript';
+
+const note = new SupernoteX(buffer);
+
+// In each Worker: toImage(pageRenderData, [1]) then encodePng(image), then
+// postMessage the PNG bytes back. See tests/fixtures/render-worker.mjs and
+// tests/pdf-worker-roundtrip.test.ts for a full worker_threads example.
+const pngBuffers = await Promise.all(
+  note.pages.map((_, i) => renderInWorker(extractPageRenderData(note, i + 1))),
+);
+
+// Back on the main thread: assemble the PDF from the rendered pages.
+const ctx = await createPdfContext();
+for (let i = 0; i < note.pages.length; i++) {
+  await addPdfPage(ctx, note.pages[i], pngBuffers[i]);
+}
+const pdfBytes = await ctx.pdfDoc.save();
+```
+
+Note that only page rendering (`toImage`/`encodePng`) is parallelizable this way — PDF assembly, including the final `pdfDoc.save()`, is a single main-thread operation regardless of how many Workers rendered pages.
+
 ## Developer Notes
 
 ### Test Individual Suite

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "tsc",
     "clean": "rm -f tests/output/*.png tests/output/*.jpg tests/output/*.pdf tests/output/*.cpuprofile",
     "lint": "eslint .",
+    "pretest": "npm run build",
     "test": "vitest run",
     "test-watch": "vitest",
     "bench": "vitest bench",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "pretest": "npm run build",
     "test": "vitest run",
     "test-watch": "vitest",
+    "prebench": "npm run build",
     "bench": "vitest bench",
     "test-mirror": "vitest --watch -t mirror",
     "coverage": "vitest run --coverage",

--- a/plans/rtr-searchable-pdf-workers.md
+++ b/plans/rtr-searchable-pdf-workers.md
@@ -41,6 +41,15 @@ Let an application render pages in parallel across Web Workers (browser) or `wor
 - Not parallelizing the invisible-text-drawing loop itself (cheap relative to RLE decode; not worth the complexity per the spike in step 1, pending its result).
 - Not pursuing per-page PDF merge (Option B: build single-page PDFs in workers, merge via `PDFDocument.copyPages`) unless step 1's profiling shows assembly is a meaningful fraction of total time — it adds real complexity (duplicated embedded fonts inflate file size unless deduped).
 
-## Open question for whoever implements this
+## Step 1 profiling result (resolves the open question below)
 
-Step 1's profiling result decides whether this plan is even the right shape — if PDF assembly turns out to be non-trivial too, Option B needs its own design pass before implementation starts.
+Measured on `tests/input/1to10.note` (10 pages), one-shot timing (not the noisier `vitest bench` warmup average) via `createPdfContext`/`addPdfPage`:
+
+| Phase | Time | Worker-eligible? |
+|---|---|---|
+| `toImage` (RLE decode + composite) | 120ms (5%) | yes |
+| `encodePng` | 1059ms (40%) | yes |
+| `addPdfPage` loop (`embedPng` + `drawImage` + text operators) | 538ms (21%) | no — needs `pdf-lib` objects |
+| `pdfDoc.save()` | 886ms (34%) | no — one-time, whole-document |
+
+Contrary to this plan's original assumption, PDF assembly is *not* cheap relative to rendering — `encodePng` (not raster decode) dominates the worker-eligible side, and main-thread-only work is 55% of total time. However, 34 of those 55 points are `pdfDoc.save()`, a single whole-document serialization that happens once regardless of how many pages were rendered where — it isn't a per-page cost Option B's per-page-PDF-merge approach would eliminate (a merged document still needs one final `save()` over the same total embedded-image payload). So Option B's added complexity (duplicate embedded fonts, `copyPages` merge) would only reach the 21% `addPdfPage`-loop slice, not the dominant 34% `save()` floor — not judged worth it. **Decision: implement Option A only** (this is what's built below); an app parallelizing `toImage`+`encodePng` across N workers should expect roughly `(45%/N) + 55%` of baseline wall-clock time, not a full `1/N`.

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -1,6 +1,33 @@
-import { ILayer, ISupernote } from './format';
+import { ILayerNames, ISupernote } from './format.js';
 import { Image, ImageColorModel, decodePng } from "image-js";
 import Color, { ColorInstance } from 'color';
+
+/** The minimal layer shape `toImage` needs to rasterize a page: enough to
+ * decode/composite, without the address/protocol metadata `ILayer` carries. */
+export interface IRenderableLayer {
+	LAYERNAME: ILayerNames;
+	bitmapBuffer: Uint8Array | null;
+}
+
+/** The minimal page shape `toImage` needs to rasterize a page. Only layers
+ * named in `LAYERSEQ` need to be present. */
+export interface IRenderablePage extends Partial<Record<ILayerNames, IRenderableLayer>> {
+	PAGESTYLE: string;
+	LAYERSEQ: ILayerNames[];
+}
+
+/** The minimal note shape `toImage` needs: page pixel dimensions plus the
+ * per-page layer data, without the class instance or unrelated pages/fields.
+ * `ISupernote` (and its full `IPage`/`ILayer` types) satisfy this structurally,
+ * so `toImage` continues to accept `ISupernote` unchanged; this narrower type
+ * additionally lets a single-page slice (see `extractPageRenderData`) be
+ * passed to `toImage` after being sent through a Worker's structured clone,
+ * without reconstructing a fake `ISupernote`. */
+export interface IRenderableNote {
+	pageWidth: number;
+	pageHeight: number;
+	pages: IRenderablePage[];
+}
 
 // True when the platform stores the least-significant byte of a multi-byte
 // value first in memory (true for every runtime this library targets, i.e.
@@ -68,17 +95,18 @@ function compositeImages(sourceImage: Image, destinationImage: Image) {
 
 /**
  * Convert a Supernote file to one or more image-js image objects.
- * @param note Parsed Supernote.
+ * @param note Parsed Supernote, or the minimal `IRenderableNote` slice
+ * produced by `extractPageRenderData` (e.g. when rendering off-main-thread).
  * @param pageNumbers Optional page numbers to export (defaults to all). Indexing starts at 1.
  */
-export function toImage(note: ISupernote, pageNumbers?: number[]) {
+export function toImage(note: IRenderableNote, pageNumbers?: number[]) {
 	const pages = pageNumbers
 		? pageNumbers.map((n) => note.pages[n - 1])
 		: note.pages;
 	const decoder = new RattaRLEDecoder();
 	return Promise.all(
 		pages.map(async (page) => {
-			const overlays = page.LAYERSEQ.map((name) => page[name] as ILayer).filter(
+			const overlays = page.LAYERSEQ.map((name) => page[name] as IRenderableLayer).filter(
 				(layer) => layer.bitmapBuffer !== null && layer.bitmapBuffer.length,
 			);
 
@@ -113,6 +141,33 @@ export function toImage(note: ISupernote, pageNumbers?: number[]) {
 			return output;
 		}),
 	);
+}
+
+/**
+ * Extracts the minimal, structured-clone-safe slice of `note` needed to
+ * render page `pageNumber` off-main-thread (e.g. posted to a Web Worker or
+ * `worker_threads` worker), without cloning the whole note (every other
+ * page's buffers, or the `SupernoteX` instance and its methods, which don't
+ * survive structured clone). Feed the result straight back into `toImage`:
+ * `toImage(extractPageRenderData(note, n), [1])`.
+ * @param note Parsed Supernote.
+ * @param pageNumber Page number to extract (1-indexed).
+ */
+export function extractPageRenderData(note: ISupernote, pageNumber: number): IRenderableNote {
+	const page = note.pages[pageNumber - 1];
+	const renderablePage: IRenderablePage = {
+		PAGESTYLE: page.PAGESTYLE,
+		LAYERSEQ: page.LAYERSEQ,
+	};
+	for (const name of page.LAYERSEQ) {
+		const layer = page[name];
+		renderablePage[name] = { LAYERNAME: layer.LAYERNAME, bitmapBuffer: layer.bitmapBuffer };
+	}
+	return {
+		pageWidth: note.pageWidth,
+		pageHeight: note.pageHeight,
+		pages: [renderablePage],
+	};
 }
 
 /** Color palette to use as substitutes for the Supernote's colors. */

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
-export { SupernoteX, extractText, extractParagraphs } from './parsing';
-export { toImage } from './conversion';
-export { fetchMirrorFrame } from './mirror';
-export { toPdf } from './pdf';
-export type { ToPdfOptions } from './pdf';
+export { SupernoteX, extractText, extractParagraphs } from './parsing.js';
+export { toImage, extractPageRenderData } from './conversion.js';
+export type { IRenderableNote, IRenderablePage, IRenderableLayer } from './conversion.js';
+export { fetchMirrorFrame } from './mirror.js';
+export { toPdf, createPdfContext, addPdfPage } from './pdf.js';
+export type { ToPdfOptions, PdfContext, AddPdfPageOptions } from './pdf.js';

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -11,7 +11,7 @@ import {
 	IPage,
 	ISupernote,
 	ITitle,
-} from './format';
+} from './format.js';
 
 /*
  * Need to make sure that buffer isn't trying to write out of bounds.

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -12,9 +12,9 @@ import {
 	showText,
 } from 'pdf-lib';
 import fontkit from '@pdf-lib/fontkit';
-import { encodePng } from 'image-js';
-import { toImage } from './conversion';
-import { ISupernote } from './format';
+import { Image, encodePng } from 'image-js';
+import { toImage } from './conversion.js';
+import { ISupernote, IPage } from './format.js';
 
 // Empirically-verified constant used by Supernote's own recognition format:
 // recognized word bounding boxes are stored in raster-pixel units divided by
@@ -35,18 +35,20 @@ export interface ToPdfOptions {
 	dpi?: number;
 }
 
-/**
- * Render a Supernote note to a PDF where each page shows the rasterized
- * page image with the recognized handwriting (RTR) text drawn invisibly on
- * top of it, at the position it was written, so PDF viewers can search for
- * and select the handwritten words.
- */
-export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promise<Uint8Array> {
-	const { pageNumbers, fontBytes, dpi = 300 } = options;
-	const pages = pageNumbers ? pageNumbers.map((n) => note.pages[n - 1]) : note.pages;
-	const images = await toImage(note, pageNumbers);
-	const pointsPerPixel = 72 / dpi;
+export interface PdfContext {
+	pdfDoc: PDFDocument;
+	font: PDFFont;
+}
 
+/**
+ * Creates the PDF document and embeds the invisible-text-layer font.
+ * Main-thread only: the returned `pdf-lib` objects aren't structured-clone-safe
+ * and so can't be created in or handed to a Worker.
+ */
+export async function createPdfContext(
+	options: Pick<ToPdfOptions, 'fontBytes'> = {},
+): Promise<PdfContext> {
+	const { fontBytes } = options;
 	const pdfDoc = await PDFDocument.create();
 
 	let font: PDFFont;
@@ -57,72 +59,122 @@ export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promi
 		font = await pdfDoc.embedFont(StandardFonts.Helvetica);
 	}
 
-	for (let i = 0; i < pages.length; i++) {
-		const page = pages[i];
-		const image = images[i];
+	return { pdfDoc, font };
+}
 
-		const widthPts = image.width * pointsPerPixel;
-		const heightPts = image.height * pointsPerPixel;
+export interface AddPdfPageOptions {
+	/** Assumed pixel density of the source page raster; see `ToPdfOptions.dpi`. */
+	dpi?: number;
+}
 
-		const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
-		const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
+/**
+ * Adds one rendered page to `ctx`: the page image, plus the recognized
+ * handwriting (RTR) text drawn invisibly on top of it at the position it was
+ * written, so PDF viewers can search for and select the handwritten words.
+ *
+ * `image` may be an `image-js` `Image` (e.g. straight from `toImage`) or
+ * already-PNG-encoded bytes (e.g. from a Worker that already called
+ * `toImage` + `encodePng` off-main-thread) — accepting bytes avoids the main
+ * thread needing to reconstruct an `Image` just to re-encode it.
+ *
+ * Main-thread only: `ctx` holds `pdf-lib` objects.
+ */
+export async function addPdfPage(
+	ctx: PdfContext,
+	page: IPage,
+	image: Image | Uint8Array,
+	options: AddPdfPageOptions = {},
+): Promise<void> {
+	const { dpi = 300 } = options;
+	const { pdfDoc, font } = ctx;
+	const pointsPerPixel = 72 / dpi;
 
-		const pngImage = await pdfDoc.embedPng(encodePng(image));
-		pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
+	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
+	const pngImage = await pdfDoc.embedPng(pngBytes);
 
-		for (const element of page.recognitionElements) {
-			if (element.type !== 'Text') continue;
+	const widthPts = pngImage.width * pointsPerPixel;
+	const heightPts = pngImage.height * pointsPerPixel;
 
-			for (const word of element.words) {
-				const box = word['bounding-box'];
-				if (!box) continue;
+	const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
+	const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
 
-				const label = decodeURIComponent(escape(word.label));
-				if (!label) continue;
+	pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
 
-				const xPx = box.x * RECOGNITION_COORDINATE_SCALE;
-				const yPx = box.y * RECOGNITION_COORDINATE_SCALE;
-				const widthPx = box.width * RECOGNITION_COORDINATE_SCALE;
-				const heightPx = box.height * RECOGNITION_COORDINATE_SCALE;
+	for (const element of page.recognitionElements) {
+		if (element.type !== 'Text') continue;
 
-				const boxWidthPts = widthPx * pointsPerPixel;
-				const boxHeightPts = heightPx * pointsPerPixel;
-				const x = xPx * pointsPerPixel;
-				// PDF's y-axis runs bottom-up; recognition boxes are top-down.
-				const y = heightPts - (yPx * pointsPerPixel + boxHeightPts);
+		for (const word of element.words) {
+			const box = word['bounding-box'];
+			if (!box) continue;
 
-				// Size the font to the box height, then use horizontal scaling
-				// (the PDF `Tz` operator) to stretch or squeeze the text to
-				// exactly match the box width in both directions — handwriting
-				// is rarely the same width as print at a given height (cursive
-				// runs narrower, print can run wider) — so that PDF viewers'
-				// search-hit highlight rectangle lines up with the ink instead
-				// of just not overflowing it.
-				try {
-					const fontSize = boxHeightPts;
-					const naturalWidth = font.widthOfTextAtSize(label, fontSize);
-					const horizontalScale = naturalWidth > 0 ? (boxWidthPts / naturalWidth) * 100 : 100;
+			const label = decodeURIComponent(escape(word.label));
+			if (!label) continue;
 
-					pdfPage.pushOperators(
-						beginText(),
-						setTextRenderingMode(TextRenderingMode.Invisible),
-						setFontAndSize(fontKey, fontSize),
-						setCharacterSqueeze(horizontalScale),
-						moveText(x, y),
-						showText(font.encodeText(label)),
-						endText(),
-					);
-				} catch {
-					// The active font (Helvetica by default) can't encode every
-					// character recognition may produce (e.g. superscripts, smart
-					// punctuation). Skip this word rather than losing the whole
-					// PDF over one unsearchable word; pass a Unicode `fontBytes`
-					// font via ToPdfOptions to cover more characters.
-					continue;
-				}
+			const xPx = box.x * RECOGNITION_COORDINATE_SCALE;
+			const yPx = box.y * RECOGNITION_COORDINATE_SCALE;
+			const widthPx = box.width * RECOGNITION_COORDINATE_SCALE;
+			const heightPx = box.height * RECOGNITION_COORDINATE_SCALE;
+
+			const boxWidthPts = widthPx * pointsPerPixel;
+			const boxHeightPts = heightPx * pointsPerPixel;
+			const x = xPx * pointsPerPixel;
+			// PDF's y-axis runs bottom-up; recognition boxes are top-down.
+			const y = heightPts - (yPx * pointsPerPixel + boxHeightPts);
+
+			// Size the font to the box height, then use horizontal scaling
+			// (the PDF `Tz` operator) to stretch or squeeze the text to
+			// exactly match the box width in both directions — handwriting
+			// is rarely the same width as print at a given height (cursive
+			// runs narrower, print can run wider) — so that PDF viewers'
+			// search-hit highlight rectangle lines up with the ink instead
+			// of just not overflowing it.
+			try {
+				const fontSize = boxHeightPts;
+				const naturalWidth = font.widthOfTextAtSize(label, fontSize);
+				const horizontalScale = naturalWidth > 0 ? (boxWidthPts / naturalWidth) * 100 : 100;
+
+				pdfPage.pushOperators(
+					beginText(),
+					setTextRenderingMode(TextRenderingMode.Invisible),
+					setFontAndSize(fontKey, fontSize),
+					setCharacterSqueeze(horizontalScale),
+					moveText(x, y),
+					showText(font.encodeText(label)),
+					endText(),
+				);
+			} catch {
+				// The active font (Helvetica by default) can't encode every
+				// character recognition may produce (e.g. superscripts, smart
+				// punctuation). Skip this word rather than losing the whole
+				// PDF over one unsearchable word; pass a Unicode `fontBytes`
+				// font via ToPdfOptions to cover more characters.
+				continue;
 			}
 		}
 	}
+}
 
-	return pdfDoc.save();
+/**
+ * Render a Supernote note to a PDF where each page shows the rasterized
+ * page image with the recognized handwriting (RTR) text drawn invisibly on
+ * top of it, at the position it was written, so PDF viewers can search for
+ * and select the handwritten words.
+ *
+ * Convenience wrapper around `createPdfContext` + `addPdfPage`, all run on
+ * the current thread. To render pages in parallel across Workers, call
+ * `extractPageRenderData` + `toImage` + `encodePng` in each Worker and
+ * `createPdfContext` + `addPdfPage` on the main thread instead — see the
+ * README.
+ */
+export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promise<Uint8Array> {
+	const { pageNumbers, fontBytes, dpi } = options;
+	const pages = pageNumbers ? pageNumbers.map((n) => note.pages[n - 1]) : note.pages;
+	const images = await toImage(note, pageNumbers);
+
+	const ctx = await createPdfContext({ fontBytes });
+	for (let i = 0; i < pages.length; i++) {
+		await addPdfPage(ctx, pages[i], images[i], { dpi });
+	}
+
+	return ctx.pdfDoc.save();
 }

--- a/tests/fixtures/render-worker-pool.mjs
+++ b/tests/fixtures/render-worker-pool.mjs
@@ -1,0 +1,14 @@
+// Persistent worker_threads entry point for tests/pdf-parallel.bench.ts.
+// Unlike render-worker.mjs (one task per Worker instantiation, used by the
+// worker_threads round-trip test), this stays alive and answers repeated
+// render requests over postMessage, so a benchmark can amortize Worker
+// startup across many pages instead of paying it per page.
+import { parentPort } from 'node:worker_threads';
+import { encodePng } from 'image-js';
+import { toImage } from '../../lib/conversion.js';
+
+parentPort.on('message', async (pageRenderData) => {
+	const [image] = await toImage(pageRenderData, [1]);
+	const pngBytes = encodePng(image);
+	parentPort.postMessage(pngBytes, [pngBytes.buffer]);
+});

--- a/tests/fixtures/render-worker.mjs
+++ b/tests/fixtures/render-worker.mjs
@@ -1,0 +1,12 @@
+// Plain-JS worker_threads entry point for tests/pdf-worker-roundtrip.test.ts.
+// worker_threads can't load .ts directly, so this imports the built output
+// (lib/, produced by `npm run build`, which the `pretest` script guarantees
+// exists) rather than src/ — exercising exactly what an application's own
+// Worker would do with this library's published package.
+import { parentPort, workerData } from 'node:worker_threads';
+import { encodePng } from 'image-js';
+import { toImage } from '../../lib/conversion.js';
+
+const [image] = await toImage(workerData.pageRenderData, [1]);
+const pngBytes = encodePng(image);
+parentPort.postMessage(pngBytes, [pngBytes.buffer]);

--- a/tests/pdf-parallel.bench.ts
+++ b/tests/pdf-parallel.bench.ts
@@ -1,0 +1,88 @@
+import * as fs from "fs-extra"
+import os from "node:os"
+import { Worker } from "node:worker_threads"
+import { bench, describe, afterAll } from 'vitest'
+import { encodePng } from "image-js"
+import { toImage, extractPageRenderData } from "../src/conversion"
+import { createPdfContext, addPdfPage } from "../src/pdf"
+import { SupernoteX } from "../src/parsing"
+
+function readFileToUint8Array(filePath: string): Uint8Array {
+	const data = fs.readFileSync(`tests/input/${filePath}`);
+	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
+/** A minimal persistent worker pool, built only for this benchmark — per
+ * plans/rtr-searchable-pdf-workers.md, orchestration is application-specific
+ * and out of this library's scope (see the README's own example). Workers
+ * stay alive across requests (render-worker-pool.mjs), so pool/Worker
+ * startup cost is paid once, not per page, matching how a long-lived app
+ * would use this. */
+function createPool(size: number) {
+	const workers = Array.from(
+		{ length: size },
+		() => new Worker(new URL("./fixtures/render-worker-pool.mjs", import.meta.url)),
+	);
+	let next = 0;
+
+	function render(pageRenderData: unknown): Promise<Uint8Array> {
+		const worker = workers[next];
+		next = (next + 1) % workers.length;
+		return new Promise((resolve, reject) => {
+			const onMessage = (pngBytes: Uint8Array) => {
+				worker.off("error", onError);
+				resolve(pngBytes);
+			};
+			const onError = (err: unknown) => {
+				worker.off("message", onMessage);
+				reject(err);
+			};
+			worker.once("message", onMessage);
+			worker.once("error", onError);
+			worker.postMessage(pageRenderData);
+		});
+	}
+
+	function terminate() {
+		return Promise.all(workers.map((worker) => worker.terminate()));
+	}
+
+	return { render, terminate };
+}
+
+const file = "1to10.note";
+const sn = new SupernoteX(readFileToUint8Array(file));
+const poolSize = Math.max(2, Math.min(4, os.cpus().length));
+const pool = createPool(poolSize);
+
+afterAll(() => pool.terminate());
+
+// Confirms plans/rtr-searchable-pdf-workers.md's premise end-to-end: that
+// parallelizing render (toImage + encodePng) across Workers, then
+// assembling on the main thread via createPdfContext/addPdfPage, is
+// actually faster wall-clock than doing everything on one thread — not
+// just that the render portion is theoretically parallelizable.
+describe(`toPdf serial vs. worker-parallel (${file}, ${sn.pages.length} pages, pool=${poolSize})`, () => {
+	bench("serial: single-thread toImage + encodePng + assemble", async () => {
+		const images = await toImage(sn);
+		const pngBytes = images.map((image) => encodePng(image));
+
+		const ctx = await createPdfContext();
+		for (let i = 0; i < sn.pages.length; i++) {
+			await addPdfPage(ctx, sn.pages[i], pngBytes[i]);
+		}
+		await ctx.pdfDoc.save();
+	});
+
+	bench(`parallel: ${poolSize}-worker render pool + main-thread assemble`, async () => {
+		const pngBytes = await Promise.all(
+			sn.pages.map((_, i) => pool.render(extractPageRenderData(sn, i + 1))),
+		);
+
+		const ctx = await createPdfContext();
+		for (let i = 0; i < sn.pages.length; i++) {
+			await addPdfPage(ctx, sn.pages[i], pngBytes[i]);
+		}
+		await ctx.pdfDoc.save();
+	});
+});

--- a/tests/pdf-worker-roundtrip.test.ts
+++ b/tests/pdf-worker-roundtrip.test.ts
@@ -1,0 +1,65 @@
+import * as fs from "fs-extra"
+import { existsSync } from "fs"
+import { Worker } from "node:worker_threads"
+import { decodePng } from "image-js"
+import { describe, test, expect, beforeAll } from 'vitest'
+import { extractPageRenderData, toImage } from "../src/conversion"
+import { SupernoteX } from "../src/parsing"
+
+function readFileToUint8Array(filePath: string): Uint8Array {
+	const data = fs.readFileSync(`tests/input/${filePath}`);
+	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
+function runRenderWorker(pageRenderData: unknown): Promise<Uint8Array> {
+	return new Promise((resolve, reject) => {
+		const worker = new Worker(new URL("./fixtures/render-worker.mjs", import.meta.url), {
+			workerData: { pageRenderData },
+		});
+		worker.once("message", (pngBytes: Uint8Array) => {
+			worker.terminate();
+			resolve(pngBytes);
+		});
+		worker.once("error", reject);
+	});
+}
+
+describe("worker-parallel page rendering", () => {
+	beforeAll(() => {
+		if (!existsSync("lib/conversion.js")) {
+			throw new Error(
+				"lib/conversion.js not found — this test exercises the worker_threads " +
+				"round trip against the built package (worker_threads can't load .ts " +
+				"directly). Run `npm run build` first (the `pretest` script does this " +
+				"automatically for `npm test`).",
+			);
+		}
+	});
+
+	test("extractPageRenderData survives structured clone and round-trips through a worker", { timeout: 30000 }, async () => {
+		const sn = new SupernoteX(readFileToUint8Array("1to10.note"));
+		const renderData = extractPageRenderData(sn, 1);
+
+		// structuredClone is what postMessage uses internally; assert it
+		// doesn't throw as a direct sanity check on clone-safety, independent
+		// of whether the worker itself is wired up correctly.
+		expect(() => structuredClone(renderData)).not.toThrow();
+
+		const pngBytes = await runRenderWorker(renderData);
+		const workerImage = decodePng(pngBytes);
+
+		const [mainThreadImage] = await toImage(sn, [1]);
+
+		expect(workerImage.width).toBe(mainThreadImage.width);
+		expect(workerImage.height).toBe(mainThreadImage.height);
+
+		// Not `.toEqual()`: on a multi-megabyte mismatch, vitest's failure-diff
+		// machinery walks/prints the arrays element-by-element and can exhaust
+		// the heap. A manual byte compare gives the same guarantee cheaply.
+		const workerData = workerImage.getRawImage().data;
+		const mainThreadData = mainThreadImage.getRawImage().data;
+		const workerBytes = Buffer.from(workerData.buffer, workerData.byteOffset, workerData.byteLength);
+		const mainThreadBytes = Buffer.from(mainThreadData.buffer, mainThreadData.byteOffset, mainThreadData.byteLength);
+		expect(Buffer.compare(workerBytes, mainThreadBytes)).toBe(0);
+	});
+});

--- a/tests/pdf.bench.ts
+++ b/tests/pdf.bench.ts
@@ -1,0 +1,38 @@
+import * as fs from "fs-extra"
+import { bench, describe } from 'vitest'
+import { encodePng } from "image-js"
+import { toImage } from "../src/conversion"
+import { createPdfContext, addPdfPage } from "../src/pdf"
+import { SupernoteX } from "../src/parsing"
+
+function readFileToUint8Array(filePath: string): Uint8Array {
+	const data = fs.readFileSync(`tests/input/${filePath}`);
+	return new Uint8Array(data.buffer, data.byteOffset, data.byteLength);
+}
+
+// Profiling spike for plans/rtr-searchable-pdf-workers.md step 1: measures
+// how much of toPdf()'s total time is spent in the CPU-heavy, worker-safe
+// render step (toImage + encodePng — both are what a Worker would run, per
+// the README's documented pattern) vs. the main-thread-only assembly step
+// (createPdfContext + addPdfPage given already-encoded PNG bytes), to decide
+// whether parallelizing render alone (Option A) captures most of the win.
+const file = "1to10.note";
+const buf = readFileToUint8Array(file);
+const sn = new SupernoteX(buf);
+const images = await toImage(sn);
+const pngBytes = images.map((image) => encodePng(image));
+
+describe(`toPdf phases (${file}, ${sn.pages.length} pages)`, () => {
+	bench("render (toImage + encodePng, all pages — worker-eligible)", async () => {
+		const rendered = await toImage(sn);
+		for (const image of rendered) encodePng(image);
+	});
+
+	bench("assemble (createPdfContext + addPdfPage loop, pre-encoded PNG bytes — main-thread-only)", async () => {
+		const ctx = await createPdfContext();
+		for (let i = 0; i < sn.pages.length; i++) {
+			await addPdfPage(ctx, sn.pages[i], pngBytes[i]);
+		}
+		await ctx.pdfDoc.save();
+	});
+});

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -1,5 +1,7 @@
 import * as fs from "fs-extra"
-import { toPdf } from "../src/pdf"
+import { encodePng } from "image-js"
+import { toPdf, createPdfContext, addPdfPage } from "../src/pdf"
+import { toImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
 import { PDFParse } from "pdf-parse"
 import { describe, test, expect } from 'vitest'
@@ -66,5 +68,51 @@ describe("pdf", () => {
     for (const word of ["Saturn", "Mercury", "Moon", "MAGUS"]) {
       expect(result.text).toContain(word)
     }
+  })
+
+  test("toPdf() produces text equivalent to manual createPdfContext + addPdfPage composition", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+
+    const viaToPdf = await toPdf(sn)
+
+    const ctx = await createPdfContext()
+    const images = await toImage(sn)
+    for (let i = 0; i < sn.pages.length; i++) {
+      await addPdfPage(ctx, sn.pages[i], images[i])
+    }
+    const viaManualComposition = await ctx.pdfDoc.save()
+
+    const parserA = new PDFParse({ data: viaToPdf })
+    const textA = await parserA.getText()
+    await parserA.destroy()
+
+    const parserB = new PDFParse({ data: viaManualComposition })
+    const textB = await parserB.getText()
+    await parserB.destroy()
+
+    expect(textA.text).toBe(textB.text)
+  })
+
+  test("addPdfPage accepts either an Image or pre-encoded PNG bytes with equivalent output", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const [image] = await toImage(sn, [1])
+
+    const ctxWithImage = await createPdfContext()
+    await addPdfPage(ctxWithImage, sn.pages[0], image)
+    const pdfFromImage = await ctxWithImage.pdfDoc.save()
+
+    const ctxWithBytes = await createPdfContext()
+    await addPdfPage(ctxWithBytes, sn.pages[0], encodePng(image))
+    const pdfFromBytes = await ctxWithBytes.pdfDoc.save()
+
+    const parserA = new PDFParse({ data: pdfFromImage })
+    const textA = await parserA.getText()
+    await parserA.destroy()
+
+    const parserB = new PDFParse({ data: pdfFromBytes })
+    const textB = await parserB.getText()
+    await parserB.destroy()
+
+    expect(textA.text).toBe(textB.text)
   })
 })


### PR DESCRIPTION
## Summary
- Implements `plans/rtr-searchable-pdf-workers.md`: splits `toPdf()` into `createPdfContext` (font/document setup) + `addPdfPage` (per-page image embed + invisible RTR text layer), so applications can render pages in parallel across Web Workers / `worker_threads` while PDF assembly (which needs non-clonable `pdf-lib` objects) stays on the main thread. `toPdf()` itself is now a thin wrapper and its behavior/signature is unchanged.
- Adds `extractPageRenderData(note, pageNumber)`, exported alongside a widened `toImage` parameter type (`IRenderableNote`), so a single page's render-only data can be posted to a Worker without cloning the whole note or reconstructing a fake `SupernoteX`.
- `addPdfPage` accepts either an `image-js` `Image` or pre-encoded PNG bytes, so a Worker that already ran `toImage` + `encodePng` can hand back just bytes.
- Profiling (`tests/pdf.bench.ts`; one-shot breakdown recorded in the plan doc) found `encodePng`, not RLE decode, dominates the worker-eligible side of the work, and that `pdfDoc.save()` alone is ~34% of total time and inherently unparallelizable (one whole-document serialization, regardless of how pages were rendered) — so this implements render-only parallelism (Option A) and skips per-page PDF merging (Option B), per the plan's non-goals.
- Fixes relative imports in `src/` to include explicit `.js` extensions. `tsc`'s `"bundler"` module resolution allowed omitting them, but that left the built `lib/` output unloadable by Node's own ESM resolver — needed here because the new `worker_threads` round-trip test's worker fixture (`tests/fixtures/render-worker.mjs`) loads `lib/` directly (workers can't run `.ts`).
- Adds a `pretest` script (`npm run build`) so `npm test` reliably has `lib/` built locally; CI already builds before testing.
- Documents the application-side Worker orchestration pattern in the README.

## Test plan
- [x] `npm run build`
- [x] `npm run lint`
- [x] `npm test` (21 tests across `main.test.ts`, `pdf.test.ts`, `pdf-worker-roundtrip.test.ts`, all passing, including the 4 pre-existing `pdf.test.ts` cases unmodified)
- [x] New: `toPdf()` output is text-equivalent to manual `createPdfContext`+`addPdfPage` composition (backward-compat check)
- [x] New: `addPdfPage` given an `Image` vs. pre-encoded PNG bytes produces text-equivalent output
- [x] New: real `worker_threads` round trip — `extractPageRenderData` → `structuredClone` sanity check → Worker renders via `toImage`+`encodePng` → main thread `decodePng`s the result and byte-compares against a main-thread `toImage` render (byte-identical)
- [x] `npx vitest bench tests/pdf.bench.ts` for the render-vs-assemble timing breakdown