### PR TITLE
Add addTextOnlyPdfPage(): a PDF page with recognized text but no image

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,5 +3,5 @@ export { toImage, extractPageRenderData } from './conversion.js';
 export type { IRenderableNote, IRenderablePage, IRenderableLayer } from './conversion.js';
 export type { ILink, IPage } from './format.js';
 export { fetchMirrorFrame } from './mirror.js';
-export { toPdf, createPdfContext, addPdfPage } from './pdf.js';
+export { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from './pdf.js';
 export type { ToPdfOptions, PdfContext, AddPdfPageOptions } from './pdf.js';

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -1,6 +1,8 @@
 import {
 	PDFDocument,
 	PDFFont,
+	PDFName,
+	PDFPage,
 	StandardFonts,
 	TextRenderingMode,
 	beginText,
@@ -67,39 +69,19 @@ export interface AddPdfPageOptions {
 	dpi?: number;
 }
 
-/**
- * Adds one rendered page to `ctx`: the page image, plus the recognized
- * handwriting (RTR) text drawn invisibly on top of it at the position it was
- * written, so PDF viewers can search for and select the handwritten words.
- *
- * `image` may be an `image-js` `Image` (e.g. straight from `toImage`) or
- * already-PNG-encoded bytes (e.g. from a Worker that already called
- * `toImage` + `encodePng` off-main-thread) — accepting bytes avoids the main
- * thread needing to reconstruct an `Image` just to re-encode it.
- *
- * Main-thread only: `ctx` holds `pdf-lib` objects.
- */
-export async function addPdfPage(
-	ctx: PdfContext,
+// Draws the recognized handwriting (RTR) text invisibly onto `pdfPage` at
+// the position it was written, so PDF viewers (or pdf.js's getTextContent())
+// can find/select/extract the handwritten words. Shared by addPdfPage() (page
+// also gets the rendered image drawn beneath this) and addTextOnlyPdfPage()
+// (no image at all — see its doc comment for when that's the right choice).
+function drawRecognitionText(
+	pdfPage: PDFPage,
+	fontKey: PDFName,
+	font: PDFFont,
 	page: IPage,
-	image: Image | Uint8Array,
-	options: AddPdfPageOptions = {},
-): Promise<void> {
-	const { dpi = 300 } = options;
-	const { pdfDoc, font } = ctx;
-	const pointsPerPixel = 72 / dpi;
-
-	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
-	const pngImage = await pdfDoc.embedPng(pngBytes);
-
-	const widthPts = pngImage.width * pointsPerPixel;
-	const heightPts = pngImage.height * pointsPerPixel;
-
-	const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
-	const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
-
-	pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
-
+	pointsPerPixel: number,
+	heightPts: number,
+): void {
 	for (const element of page.recognitionElements) {
 		if (element.type !== 'Text') continue;
 
@@ -152,6 +134,75 @@ export async function addPdfPage(
 			}
 		}
 	}
+}
+
+/**
+ * Adds one rendered page to `ctx`: the page image, plus the recognized
+ * handwriting (RTR) text drawn invisibly on top of it at the position it was
+ * written, so PDF viewers can search for and select the handwritten words.
+ *
+ * `image` may be an `image-js` `Image` (e.g. straight from `toImage`) or
+ * already-PNG-encoded bytes (e.g. from a Worker that already called
+ * `toImage` + `encodePng` off-main-thread) — accepting bytes avoids the main
+ * thread needing to reconstruct an `Image` just to re-encode it.
+ *
+ * Main-thread only: `ctx` holds `pdf-lib` objects.
+ */
+export async function addPdfPage(
+	ctx: PdfContext,
+	page: IPage,
+	image: Image | Uint8Array,
+	options: AddPdfPageOptions = {},
+): Promise<void> {
+	const { dpi = 300 } = options;
+	const { pdfDoc, font } = ctx;
+	const pointsPerPixel = 72 / dpi;
+
+	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
+	const pngImage = await pdfDoc.embedPng(pngBytes);
+
+	const widthPts = pngImage.width * pointsPerPixel;
+	const heightPts = pngImage.height * pointsPerPixel;
+
+	const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
+	const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
+
+	pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
+
+	drawRecognitionText(pdfPage, fontKey, font, page, pointsPerPixel, heightPts);
+}
+
+/**
+ * Adds one page to `ctx` with the recognized text drawn invisibly, same as
+ * addPdfPage(), but with no image at all — for a PDF whose only purpose is
+ * to be handed to pdf.js so its getTextContent()/getViewport() can be used
+ * (e.g. to build a searchable/selectable text layer over a page that's
+ * actually displayed some other way, such as a directly-rendered canvas).
+ * `pdfPage.render()` is never called against such a PDF, so the image would
+ * be pure dead weight: embedding a full-resolution PNG only for pdf-lib to
+ * decode, recompress, and serialize it is real, size-proportional work
+ * (seconds for a many-page/high-resolution note) for bytes nothing ever
+ * looks at. `pageWidth`/`pageHeight` (pixels) size the PDF page the same way
+ * the image's own dimensions would via addPdfPage().
+ */
+export async function addTextOnlyPdfPage(
+	ctx: PdfContext,
+	page: IPage,
+	pageWidth: number,
+	pageHeight: number,
+	options: AddPdfPageOptions = {},
+): Promise<void> {
+	const { dpi = 300 } = options;
+	const { pdfDoc, font } = ctx;
+	const pointsPerPixel = 72 / dpi;
+
+	const widthPts = pageWidth * pointsPerPixel;
+	const heightPts = pageHeight * pointsPerPixel;
+
+	const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
+	const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
+
+	drawRecognitionText(pdfPage, fontKey, font, page, pointsPerPixel, heightPts);
 }
 
 /**

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra"
 import { encodePng } from "image-js"
-import { toPdf, createPdfContext, addPdfPage } from "../src/pdf"
+import { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from "../src/pdf"
 import { toImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
 import { PDFParse } from "pdf-parse"
@@ -114,5 +114,40 @@ describe("pdf", () => {
     await parserB.destroy()
 
     expect(textA.text).toBe(textB.text)
+  })
+
+  test("addTextOnlyPdfPage produces the same searchable text as addPdfPage, without embedding an image", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const images = await toImage(sn)
+
+    const ctxWithImage = await createPdfContext()
+    for (let i = 0; i < sn.pages.length; i++) {
+      await addPdfPage(ctxWithImage, sn.pages[i], images[i])
+    }
+    const pdfWithImage = await ctxWithImage.pdfDoc.save()
+
+    const ctxTextOnly = await createPdfContext()
+    for (let i = 0; i < sn.pages.length; i++) {
+      await addTextOnlyPdfPage(ctxTextOnly, sn.pages[i], sn.pageWidth, sn.pageHeight)
+    }
+    const pdfTextOnly = await ctxTextOnly.pdfDoc.save()
+
+    // No image data to encode/compress/embed, so this should be dramatically
+    // smaller than the equivalent PDF with real page images — not just a
+    // marginal difference — since that's the entire point of this function.
+    expect(pdfTextOnly.byteLength).toBeLessThan(pdfWithImage.byteLength / 10)
+
+    const parserA = new PDFParse({ data: pdfWithImage })
+    const textA = await parserA.getText()
+    await parserA.destroy()
+
+    const parserB = new PDFParse({ data: pdfTextOnly })
+    const textB = await parserB.getText()
+    await parserB.destroy()
+
+    expect(textB.text).toBe(textA.text)
+    for (const word of ["Real", "time", "recognition", "paragraph", "reflow", "together"]) {
+      expect(textB.text).toContain(word)
+    }
   })
 })


### PR DESCRIPTION
## Summary

- Adds `addTextOnlyPdfPage(ctx, page, pageWidth, pageHeight, options?)`: builds a PDF page with the invisible recognized-text (RTR) layer, same as `addPdfPage()`, but embeds no image at all.
- Refactors the recognition-text-drawing loop out of `addPdfPage()` into a shared `drawRecognitionText()` helper used by both functions, so they can't drift out of sync.
- Exports the new function from `src/index.ts`.

## Why

`addPdfPage()` is correct for a PDF the user actually opens or exports — it needs the real page image. But some callers only build a PDF to hand to pdf.js purely for `getTextContent()`/`getViewport()` (e.g. building a search/selectable text layer over a page that's actually displayed some other way, like a directly-rendered `<canvas>`) and never call pdf.js's `render()` against it. For those, the embedded image is pure dead weight — and not a cheap kind. `pdf-lib`'s PNG embedding always fully decodes the PNG and recompresses it from scratch at `.save()` time (`PngEmbedder` calls `PNG.load()` then re-`flateStream`s the raw RGB/alpha planes), regardless of the source PNG already being compressed. This is real, size-proportional cost.

Profiled against a real 12-page, ~1404x1872px note with several user-uploaded-background pages:
- `addPdfPage` (image + text): ~2.9s total (`embedPng` ~0.8s, `.save()` ~2.1s), ~4.5MB output.
- `addTextOnlyPdfPage` (text only): ~40ms total, ~43KB output.
- Extracted text identical either way (verified via `pdf-parse`).

This is being consumed by philips/supernote-obsidian-plugin's `SupernoteView`, which was unconditionally paying the full image-embedding cost on every single note open just to get a text layer for search/selection, even though the image was never rendered.

## Test plan

- [x] `npx vitest run` (submodule) — 26 passed, including one new test asserting `addTextOnlyPdfPage` produces the same extracted text as `addPdfPage` for the same note, and that its output is under 1/10th the byte size.
- [x] `npm run lint` — clean
- [x] `npm run build` (`tsc`) — clean