### PR TITLE
Export RecognitionStatuses from index

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@ export { SupernoteX, extractText, extractParagraphs } from './parsing.js';
 export { toImage, extractPageRenderData } from './conversion.js';
 export type { IRenderableNote, IRenderablePage, IRenderableLayer } from './conversion.js';
 export type { ILink, IPage } from './format.js';
+export { RecognitionStatuses } from './format.js';
 export { fetchMirrorFrame } from './mirror.js';
 export { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from './pdf.js';
 export type { ToPdfOptions, PdfContext, AddPdfPageOptions } from './pdf.js';


### PR DESCRIPTION
Small addition needed by [supernote-obsidian-plugin#145](https://github.com/philips/supernote-obsidian-plugin/issues/145): the plugin's `registerPageTextProcessor` OCR hook is being extended to expose `IPage.RECOGNSTATUS` to external companion plugins, and should type it as this enum rather than a bare string so consumers can write `ctx.recognitionStatus === RecognitionStatuses.DONE` instead of comparing against magic `'0'`/`'1'`/`'2'` strings.

`RecognitionStatuses` already existed in `format.ts` and is used internally (`IPage.RECOGNSTATUS: RecognitionStatuses`) - it just wasn't re-exported from `index.ts` alongside `ILink`/`IPage`.

Stacked on by the corresponding `supernote-obsidian-plugin` PR, which bumps its submodule pointer to this branch.

## Test plan
- [x] `npm run build` - clean