### PR TITLE
Cap composited .spd image size to avoid OOM on a corrupted/outlier tile

### DIFF
--- a/src/atelier.ts
+++ b/src/atelier.ts
@@ -68,6 +68,21 @@ const SURFACE_TABLE_PATTERN = /^surface_\d+$/;
  * tiles happen to sit. */
 const TILE_ID_STRIDE = 4096;
 
+/** Hard ceiling on a composited image's total pixel count. `toImage()` sizes
+ * its output against the tile-grid bounding box across *every* tile in the
+ * file (see its doc comment) with no other check - a single tile whose `tid`
+ * is far from the rest (a corrupted file, or a stray mark placed far off on
+ * Atelier's much larger virtual canvas, see `TILE_ID_STRIDE`'s doc comment)
+ * blows that bounding box out arbitrarily far, and `toImage()` would
+ * otherwise allocate accordingly. On a memory-constrained host (verified:
+ * this is what caused supernote-obsidian-plugin#147, a hard iOS crash on
+ * open, not a catchable one - WKWebView's per-process memory ceiling is far
+ * stricter than desktop's) that's an out-of-memory crash rather than a slow
+ * tab. Real device-generated files observed so far top out around
+ * 1920x2560 (~4.9 megapixels; see atelier.test.ts) - this leaves generous
+ * headroom above that while still keeping the worst case bounded. */
+const MAX_COMPOSITE_PIXELS = 32_000_000;
+
 /** Parsed Supernote Atelier `.spd` file. */
 export class SupernoteAtelier {
 	declare fmtVer?: number;
@@ -207,7 +222,17 @@ export class SupernoteAtelier {
 
 		const tileWidth = decoded[0].image.width;
 		const tileHeight = decoded[0].image.height;
-		const output = new Image((maxCol - minCol + 1) * tileWidth, (maxRow - minRow + 1) * tileHeight, {
+		const width = (maxCol - minCol + 1) * tileWidth;
+		const height = (maxRow - minRow + 1) * tileHeight;
+		if (width * height > MAX_COMPOSITE_PIXELS) {
+			throw new Error(
+				`Refusing to composite "${surfaceName}": computed size ${width}x${height} ` +
+				`(${(width * height).toLocaleString()} px) exceeds the ${MAX_COMPOSITE_PIXELS.toLocaleString()}px ` +
+				'safety limit. This usually means one tile is positioned far from the rest ' +
+				'(a corrupted or out-of-range tile id) rather than a genuinely huge canvas.',
+			);
+		}
+		const output = new Image(width, height, {
 			colorModel: ImageColorModel.RGBA,
 		});
 		// image-js defaults a new image's alpha channel to fully opaque (and

--- a/tests/atelier.test.ts
+++ b/tests/atelier.test.ts
@@ -1,5 +1,6 @@
 import * as fs from "fs-extra"
 import * as imagejs from "image-js"
+import initSqlJs from "sql.js"
 import { describe, test, expect } from 'vitest'
 import { SupernoteAtelier } from "../src/atelier"
 
@@ -13,6 +14,31 @@ function readFileToUint8Array(filePath: string): Promise<Uint8Array> {
       }
     });
   });
+}
+
+// Minimal `.spd` SQLite database, built directly (not via a real device
+// export) so a test can place a tile wherever it wants - including
+// positions no real file would ever have, to exercise toImage()'s size
+// guard. Only what `_parseConfig`/`_parseSurfaces` actually read: a `config`
+// table (left empty here - canvasSize/layers/etc. are all optional) and one
+// `tid`/`tile` table per surface named in `tiles`.
+async function buildSpdBuffer(tiles: { surface: string; tid: number }[]): Promise<Uint8Array> {
+  const SQL = await initSqlJs();
+  const db = new SQL.Database();
+  db.run("CREATE TABLE config (name TEXT, value BLOB)");
+
+  const tilePng = imagejs.encodePng(new imagejs.Image(4, 4, { colorModel: imagejs.ImageColorModel.RGBA }));
+  const surfaceNames = new Set(tiles.map((t) => t.surface));
+  for (const surface of surfaceNames) {
+    db.run(`CREATE TABLE ${surface} (tid INTEGER, tile BLOB)`);
+  }
+  for (const { surface, tid } of tiles) {
+    db.run(`INSERT INTO ${surface} (tid, tile) VALUES (?, ?)`, [tid, tilePng]);
+  }
+
+  const buffer = db.export();
+  db.close();
+  return buffer;
 }
 
 describe("atelier", () => {
@@ -221,5 +247,37 @@ describe("atelier real device file", () => {
     const composite = await note.toCompositeImage(["surface_9999", "surface_no_such_layer"]);
     expect(composite).not.toBeNull();
     expect(composite!.getPixel(0, 0)).toEqual(background!.getPixel(0, 0));
+  })
+
+  // Regression test for supernote-obsidian-plugin#147: a tile positioned far
+  // from the rest (tid encodes grid column in its upper bits, see
+  // TILE_ID_STRIDE's doc comment in atelier.ts) used to make toImage() size
+  // its output against that outlier with no check at all, allocating
+  // gigabytes for what should be a tiny image - fine on desktop, a hard OOM
+  // crash on a memory-constrained mobile WebView.
+  test("toImage refuses to composite when a tile sits far outside the rest", async () => {
+    // tid = col * 4096 + row (TILE_ID_STRIDE). One ordinary tile at the
+    // origin, one 10 million columns away - a stand-in for a corrupted/
+    // out-of-range tid, since no real device drawing spans that far. With
+    // these 4x4 tiles that's a (10,000,001 * 4) x 4 output, comfortably over
+    // the 32-megapixel safety limit.
+    const buffer = await buildSpdBuffer([
+      { surface: "surface_1", tid: 0 },
+      { surface: "surface_1", tid: 10_000_000 * 4096 },
+    ]);
+    const note = await SupernoteAtelier.open(buffer);
+    await expect(note.toImage("surface_1")).rejects.toThrow(/exceeds the .* safety limit/);
+  })
+
+  test("toImage composites normally when tiles stay within the safety limit", async () => {
+    const buffer = await buildSpdBuffer([
+      { surface: "surface_1", tid: 0 },
+      { surface: "surface_1", tid: 1 * 4096 + 1 }, // one tile over, one down
+    ]);
+    const note = await SupernoteAtelier.open(buffer);
+    const image = await note.toImage("surface_1");
+    expect(image).not.toBeNull();
+    expect(image!.width).toEqual(4 * 2);
+    expect(image!.height).toEqual(4 * 2);
   })
 })


### PR DESCRIPTION
## Summary

Candidate fix for [supernote-obsidian-plugin#147](https://github.com/philips/supernote-obsidian-plugin/issues/147) (crash/"boot loop" opening certain notes on iOS). Note: the reporter has since clarified the crashing file in their case is a `.note` file, not `.spd`, so this fix addresses a real, independently-verified bug found while investigating that report, but may not be *the* cause of #147 itself - see that issue for the ongoing investigation into the `.note` path.

`SupernoteAtelier.toImage()` sizes its output image against the tile-grid bounding box computed across *every* tile in the file (`computeGridBounds()`), with no sanity check before allocating. A single tile whose `tid` is far from the rest - a corrupted file, or in principle a stray mark placed far off on Atelier's own much-larger virtual canvas (see `TILE_ID_STRIDE`'s doc comment) - blows that bounding box out arbitrarily far, and `new Image(width, height, ...)` allocates accordingly: potentially gigabytes for what should be a small composite.

On desktop that's slow or an OOM in one tab. On a memory-constrained mobile WebView (iOS in particular) that's a hard, non-catchable crash - exactly the shape of bug that would produce a "boot loop": the host reopens the last file on relaunch, so one bad `.spd` file crashes it again immediately, every time.

## Changes
- Adds a 32-megapixel ceiling on the composited image's total pixel count (real device-generated files observed so far top out around 1920x2560, ~4.9 megapixels - see `atelier.test.ts`), throwing a descriptive `Error` instead of allocating past it.
- The main plugin's `SupernoteAtelierView.updateImage()` already wraps this call in try/catch and renders errors in-view, so this turns a native crash into a normal, visible "couldn't open this file" error rather than requiring any change on that side.

## Test plan
- [x] `npm run build` - clean
- [x] `npx eslint src/atelier.ts tests/atelier.test.ts` - 0 errors
- [x] `npx vitest run` - 41 passed (39 previously + 2 new)
- [x] New test constructs a synthetic `.spd` SQLite database (via `sql.js` directly, not a real device export) with one tile 10 million grid-columns from the origin, confirming `toImage()` throws rather than allocating
- [x] New test confirms normal, in-bounds tile layouts still composite correctly