### PR TITLE
Mark package sideEffects:false to fix barrel tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "lib/index.js",
   "typings": "lib/index.d.ts",
   "type": "module",
+  "sideEffects": false,
   "files": [
     "lib"
   ],


### PR DESCRIPTION
## Summary
- Fixes #45. The library already ships pure ESM (`tsc` with `module: ESNext`, `"type": "module"` in package.json), but without a `sideEffects` field, bundlers must conservatively assume any module reached through the barrel `index.ts` could have side effects and keep it in the graph — so consumers importing only `SupernoteX` still got `pdf-lib`, `@pdf-lib/fontkit`, `sql.js`, and `image-js` pulled in.
- Audited every `src/*.ts` file for top-level statements: all are pure `const` bindings (no global mutation, no prototype patching, no eager `initSqlJs()` — that's only called inside functions). Safe to declare the whole package side-effect-free.
- Added `"sideEffects": false` to `package.json`.

## Verification
Bundled two entrypoints against `lib/index.js` with esbuild (`--bundle --tree-shaking=true`):

| entrypoint | before | after |
|---|---|---|
| `import { SupernoteX }` only | 2.8 MB | **18 KB** |
| `import { SupernoteX, toPdf }` | 2.8 MB | 2.8 MB (expected — `toPdf` genuinely needs `pdf-lib`) |

- `npm run build` — clean
- `npm test` — 48/48 passing
- `npm run lint` — clean

## Test plan
- [x] `npm run build`
- [x] `npm test`
- [x] `npm run lint`
- [x] Manual esbuild tree-shake check (see table above)