### PR TITLE
Export IRecognitionElement from the public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export { SupernoteX, extractText, extractParagraphs } from './parsing.js';
 export { toImage, extractPageRenderData, extractPdfPageData, flattenToWhite } from './conversion.js';
 export type { IRenderableNote, IRenderablePage, IRenderableLayer, IPdfPage, ToImageOptions } from './conversion.js';
-export type { ILink, IPage } from './format.js';
+export type { ILink, IPage, IRecognitionElement } from './format.js';
 export { RecognitionStatuses } from './format.js';
 export { fetchMirrorFrame } from './mirror.js';
 export { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from './pdf.js';


### PR DESCRIPTION
## Summary
- Adds `IRecognitionElement` to `src/index.ts`'s public type exports (alongside the existing `ILink`, `IPage`).

## Why
`supernote-obsidian-plugin` is building a from-scratch, portable word-overlay for find-in-note (no PDF/pdf.js dependency - see [issue #183](https://github.com/philips/supernote-obsidian-plugin/issues/183)), which iterates `page.recognitionElements` directly. Without this export, that consumer had no way to type the iteration without an unsafe cast.

## Test plan
- [x] `npm run build` (tsc) succeeds
- [x] `npm test` - 48/48 tests pass (no behavior change, type-only export addition)