### PR TITLE
Add SVG export

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ node_modules/
 tests/output/*.png
 tests/output/*.jpg
 tests/output/*.pdf
+tests/output/*.svg
 tests/output/*.cpuprofile
 *.DS_Store*
 .aider*

--- a/README.md
+++ b/README.md
@@ -53,6 +53,22 @@ const pdfBytes = await ctx.pdfDoc.save();
 
 Note that only page rendering (`toImage`/`encodePng`) is parallelizable this way — PDF assembly, including the final `pdfDoc.save()`, is a single main-thread operation regardless of how many Workers rendered pages.
 
+### Generating searchable SVGs
+
+`toSvg` renders each page to a standalone SVG document: the rasterized page image embedded as a base64 PNG, with the recognized handwriting (RTR) text overlaid invisibly at the position it was written, same as `toPdf`. SVG has no native multi-page container, so `toSvg` returns one SVG string per page.
+
+```ts
+import { SupernoteX, toSvg } from 'supernote-typescript';
+
+const note = new SupernoteX(buffer);
+const svgs = await toSvg(note); // one SVG document string per page
+await fs.writeFile('page-1.svg', svgs[0]);
+```
+
+Pass `{ dpi }` to size the SVG's `width`/`height` attributes in physical inches (the `viewBox`, and so the coordinate space the image and text sit in, always stays in raw pixels); pass `{ includeText: false }` to skip the text overlay and just embed the image.
+
+Like `toPdf`, `toSvg` is a convenience wrapper around lower-level pieces — `extractPdfPageData`, `toImage`/`encodePng`, and `addSvgPage` — for rendering pages in parallel across Workers. Unlike `addPdfPage`, `addSvgPage` doesn't touch any non-structured-clone-safe objects, so the whole per-page pipeline (`toImage` + `encodePng` + `addSvgPage`) can run inside a Worker, with only the resulting strings posted back to the main thread.
+
 ### Cheap thumbnails: rendering at a reduced resolution
 
 `toImage` always rasterizes at the note's native `pageWidth`×`pageHeight` — fine for a main view or export, but wasteful for something like a small thumbnail sidebar, where decoding and holding a full-resolution page in memory per thumbnail adds up fast on memory-constrained devices (this is what motivated [#40](https://github.com/philips/supernote-typescript/issues/40)). Pass `{ scale }` to render directly at a reduced resolution instead:

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build": "tsc",
-    "clean": "rm -f tests/output/*.png tests/output/*.jpg tests/output/*.pdf tests/output/*.cpuprofile",
+    "clean": "rm -f tests/output/*.png tests/output/*.jpg tests/output/*.pdf tests/output/*.svg tests/output/*.cpuprofile",
     "lint": "eslint .",
     "pretest": "npm run build",
     "test": "vitest run",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,8 @@ export { RecognitionStatuses } from './format.js';
 export { fetchMirrorFrame } from './mirror.js';
 export { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from './pdf.js';
 export type { ToPdfOptions, PdfContext, AddPdfPageOptions } from './pdf.js';
+export { toSvg, addSvgPage } from './svg.js';
+export type { ToSvgOptions, AddSvgPageOptions } from './svg.js';
 export { SupernoteAtelier } from './atelier.js';
 export type {
 	IAtelierTile,

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -21,7 +21,9 @@ import { ISupernote } from './format.js';
 // Empirically-verified constant used by Supernote's own recognition format:
 // recognized word bounding boxes are stored in raster-pixel units divided by
 // this factor. See plans/rtr-searchable-pdf.md for how this was confirmed.
-const RECOGNITION_COORDINATE_SCALE = 11.9;
+// Exported so other exporters positioning an invisible text overlay over the
+// same recognition data (e.g. svg.ts) share this instead of re-deriving it.
+export const RECOGNITION_COORDINATE_SCALE = 11.9;
 
 export interface ToPdfOptions {
 	/** Page numbers to export (1-indexed). Defaults to all pages. */

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -18,12 +18,29 @@ import { Image, encodePng } from 'image-js';
 import { toImage, IPdfPage } from './conversion.js';
 import { ISupernote } from './format.js';
 
-// Empirically-verified constant used by Supernote's own recognition format:
-// recognized word bounding boxes are stored in raster-pixel units divided by
-// this factor. See plans/rtr-searchable-pdf.md for how this was confirmed.
-// Exported so other exporters positioning an invisible text overlay over the
-// same recognition data (e.g. svg.ts) share this instead of re-deriving it.
-export const RECOGNITION_COORDINATE_SCALE = 11.9;
+// Recognized word bounding boxes are stored in raster-pixel units divided by
+// a scale factor that is *not* a universal constant: 11.9 (confirmed per
+// plans/rtr-searchable-pdf.md) only holds at the 1920px-wide reference page
+// Manta-family devices (SupernoteX's `header.APPLY_EQUIPMENT === 'N5'`
+// check) render at. Every other device family - including the far more
+// common A5X, whose default pageWidth is 1404 - needs that reference scale
+// shrunk proportionally to its own actual page width, or recognized-word
+// positions drift further from the real ink the further down the page a
+// word sits (the error is multiplicative, so it's barely visible on the
+// first line and lands on blank paper several lines down). Confirmed
+// against a real A5X note fixture in
+// https://github.com/philips/supernote-obsidian-plugin/pull/206.
+const RECOGNITION_REFERENCE_PAGE_WIDTH = 1920;
+const RECOGNITION_REFERENCE_SCALE = 11.9;
+
+/** Scale factor to convert a recognized word's native bounding-box units
+ * into raster-pixel units, for a page whose actual pixel width is
+ * `pageWidth`. Exported so other exporters positioning an invisible text
+ * overlay over the same recognition data (e.g. svg.ts) share this instead
+ * of re-deriving it. */
+export function recognitionCoordinateScale(pageWidth: number): number {
+	return (pageWidth * RECOGNITION_REFERENCE_SCALE) / RECOGNITION_REFERENCE_PAGE_WIDTH;
+}
 
 export interface ToPdfOptions {
 	/** Page numbers to export (1-indexed). Defaults to all pages. */
@@ -81,9 +98,11 @@ function drawRecognitionText(
 	fontKey: PDFName,
 	font: PDFFont,
 	page: IPdfPage,
+	pageWidth: number,
 	pointsPerPixel: number,
 	heightPts: number,
 ): void {
+	const scale = recognitionCoordinateScale(pageWidth);
 	for (const element of page.recognitionElements) {
 		if (element.type !== 'Text') continue;
 
@@ -94,10 +113,10 @@ function drawRecognitionText(
 			const label = decodeURIComponent(escape(word.label));
 			if (!label) continue;
 
-			const xPx = box.x * RECOGNITION_COORDINATE_SCALE;
-			const yPx = box.y * RECOGNITION_COORDINATE_SCALE;
-			const widthPx = box.width * RECOGNITION_COORDINATE_SCALE;
-			const heightPx = box.height * RECOGNITION_COORDINATE_SCALE;
+			const xPx = box.x * scale;
+			const yPx = box.y * scale;
+			const widthPx = box.width * scale;
+			const heightPx = box.height * scale;
 
 			const boxWidthPts = widthPx * pointsPerPixel;
 			const boxHeightPts = heightPx * pointsPerPixel;
@@ -171,7 +190,7 @@ export async function addPdfPage(
 
 	pdfPage.drawImage(pngImage, { x: 0, y: 0, width: widthPts, height: heightPts });
 
-	drawRecognitionText(pdfPage, fontKey, font, page, pointsPerPixel, heightPts);
+	drawRecognitionText(pdfPage, fontKey, font, page, pngImage.width, pointsPerPixel, heightPts);
 }
 
 /**
@@ -204,7 +223,7 @@ export async function addTextOnlyPdfPage(
 	const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
 	const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
 
-	drawRecognitionText(pdfPage, fontKey, font, page, pointsPerPixel, heightPts);
+	drawRecognitionText(pdfPage, fontKey, font, page, pageWidth, pointsPerPixel, heightPts);
 }
 
 /**

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1,6 +1,6 @@
 import { Image, encodePng } from 'image-js';
 import { toImage, IPdfPage } from './conversion.js';
-import { RECOGNITION_COORDINATE_SCALE } from './pdf.js';
+import { recognitionCoordinateScale } from './pdf.js';
 import { ISupernote } from './format.js';
 
 const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
@@ -46,7 +46,8 @@ function escapeXml(text: string): string {
  * own `textLength`/`lengthAdjust` attributes do the stretch-to-fit-the-box
  * scaling natively instead of needing a manually computed horizontal-scale
  * percentage. */
-function buildRecognitionTextElements(page: IPdfPage): string {
+function buildRecognitionTextElements(page: IPdfPage, pageWidth: number): string {
+	const scale = recognitionCoordinateScale(pageWidth);
 	const elements: string[] = [];
 	for (const element of page.recognitionElements) {
 		if (element.type !== 'Text') continue;
@@ -58,10 +59,10 @@ function buildRecognitionTextElements(page: IPdfPage): string {
 			const label = decodeURIComponent(escape(word.label));
 			if (!label) continue;
 
-			const x = box.x * RECOGNITION_COORDINATE_SCALE;
-			const y = box.y * RECOGNITION_COORDINATE_SCALE;
-			const width = box.width * RECOGNITION_COORDINATE_SCALE;
-			const height = box.height * RECOGNITION_COORDINATE_SCALE;
+			const x = box.x * scale;
+			const y = box.y * scale;
+			const width = box.width * scale;
+			const height = box.height * scale;
 			// SVG positions text by its baseline, not a bounding-box corner;
 			// anchoring at the box's bottom edge approximates the baseline
 			// closely enough for search/selection (exact glyph metrics aren't
@@ -117,7 +118,7 @@ export function addSvgPage(
 	const widthAttr = dpi ? `${pageWidth / dpi}in` : `${pageWidth}`;
 	const heightAttr = dpi ? `${pageHeight / dpi}in` : `${pageHeight}`;
 
-	const textElements = includeText ? buildRecognitionTextElements(page) : '';
+	const textElements = includeText ? buildRecognitionTextElements(page, pageWidth) : '';
 
 	return (
 		`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -1,0 +1,163 @@
+import { Image, encodePng } from 'image-js';
+import { toImage, IPdfPage } from './conversion.js';
+import { RECOGNITION_COORDINATE_SCALE } from './pdf.js';
+import { ISupernote } from './format.js';
+
+const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
+
+/** Base64-encodes `bytes` without `Buffer` (Node-only) or `btoa`
+ * (call-stack-limited on large inputs), so it works the same in Node and
+ * the browser at the size of a full-page PNG. */
+function encodeBase64(bytes: Uint8Array): string {
+	const chars: string[] = [];
+	const len = bytes.length;
+	for (let i = 0; i < len; i += 3) {
+		const b0 = bytes[i];
+		const hasB1 = i + 1 < len;
+		const hasB2 = i + 2 < len;
+		const b1 = hasB1 ? bytes[i + 1] : 0;
+		const b2 = hasB2 ? bytes[i + 2] : 0;
+
+		chars.push(BASE64_CHARS[b0 >> 2]);
+		chars.push(BASE64_CHARS[((b0 & 0x03) << 4) | (b1 >> 4)]);
+		chars.push(hasB1 ? BASE64_CHARS[((b1 & 0x0f) << 2) | (b2 >> 6)] : '=');
+		chars.push(hasB2 ? BASE64_CHARS[b2 & 0x3f] : '=');
+	}
+	return chars.join('');
+}
+
+const XML_ESCAPES: Record<string, string> = {
+	'&': '&amp;',
+	'<': '&lt;',
+	'>': '&gt;',
+	'"': '&quot;',
+	"'": '&apos;',
+};
+
+function escapeXml(text: string): string {
+	return text.replace(/[&<>"']/g, (char) => XML_ESCAPES[char]);
+}
+
+/** Builds one invisible, positioned `<text>` element per recognized word, so
+ * the word can be found/selected/copied in an SVG viewer despite the ink
+ * itself being part of the rasterized `<image>` beneath it. Mirrors
+ * `drawRecognitionText` in pdf.ts, adapted to SVG: SVG's y-axis already runs
+ * top-down like the recognition boxes (no PDF-style flip needed), and SVG's
+ * own `textLength`/`lengthAdjust` attributes do the stretch-to-fit-the-box
+ * scaling natively instead of needing a manually computed horizontal-scale
+ * percentage. */
+function buildRecognitionTextElements(page: IPdfPage): string {
+	const elements: string[] = [];
+	for (const element of page.recognitionElements) {
+		if (element.type !== 'Text') continue;
+
+		for (const word of element.words) {
+			const box = word['bounding-box'];
+			if (!box) continue;
+
+			const label = decodeURIComponent(escape(word.label));
+			if (!label) continue;
+
+			const x = box.x * RECOGNITION_COORDINATE_SCALE;
+			const y = box.y * RECOGNITION_COORDINATE_SCALE;
+			const width = box.width * RECOGNITION_COORDINATE_SCALE;
+			const height = box.height * RECOGNITION_COORDINATE_SCALE;
+			// SVG positions text by its baseline, not a bounding-box corner;
+			// anchoring at the box's bottom edge approximates the baseline
+			// closely enough for search/selection (exact glyph metrics aren't
+			// available, and this isn't rendered visibly anyway).
+			const baselineY = y + height;
+
+			elements.push(
+				`<text x="${x}" y="${baselineY}" font-size="${height}" textLength="${width}" ` +
+					`lengthAdjust="spacingAndGlyphs" fill="transparent">${escapeXml(label)}</text>`,
+			);
+		}
+	}
+	return elements.join('');
+}
+
+export interface AddSvgPageOptions {
+	/** Assumed pixel density of the source page raster, used to size the SVG
+	 * in physical units (inches) via its `width`/`height` attributes; the
+	 * `viewBox` (and so the coordinate space `image`/text sit in) always
+	 * stays in raw pixels regardless. Omit to size the SVG in pixels too. */
+	dpi?: number;
+	/** Whether to overlay the recognized handwriting (RTR) text invisibly, as
+	 * `addPdfPage` does for PDF output. Default true. */
+	includeText?: boolean;
+}
+
+/**
+ * Builds one standalone SVG document for a page: the rasterized image
+ * embedded as a base64 data URI, with the recognized handwriting (RTR) text
+ * drawn invisibly on top at the position it was written, so the word can be
+ * found/selected/copied in an SVG viewer that supports text search (e.g. a
+ * browser).
+ *
+ * `image` may be an `image-js` `Image` (e.g. straight from `toImage`) or
+ * already-PNG-encoded bytes (e.g. from a Worker that already called
+ * `toImage` + `encodePng` off-main-thread). Unlike `addPdfPage`, this
+ * doesn't touch any non-structured-clone-safe objects, so — one more
+ * difference from the PDF path — it can run inside a Worker too, not just on
+ * the main thread.
+ */
+export function addSvgPage(
+	page: IPdfPage,
+	image: Image | Uint8Array,
+	pageWidth: number,
+	pageHeight: number,
+	options: AddSvgPageOptions = {},
+): string {
+	const { dpi, includeText = true } = options;
+
+	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
+	const base64 = encodeBase64(pngBytes);
+
+	const widthAttr = dpi ? `${pageWidth / dpi}in` : `${pageWidth}`;
+	const heightAttr = dpi ? `${pageHeight / dpi}in` : `${pageHeight}`;
+
+	const textElements = includeText ? buildRecognitionTextElements(page) : '';
+
+	return (
+		`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
+		`width="${widthAttr}" height="${heightAttr}" viewBox="0 0 ${pageWidth} ${pageHeight}">` +
+		`<image x="0" y="0" width="${pageWidth}" height="${pageHeight}" xlink:href="data:image/png;base64,${base64}"/>` +
+		textElements +
+		`</svg>`
+	);
+}
+
+export interface ToSvgOptions {
+	/** Page numbers to export (1-indexed). Defaults to all pages. */
+	pageNumbers?: number[];
+	/** See `AddSvgPageOptions.dpi`. */
+	dpi?: number;
+	/** See `AddSvgPageOptions.includeText`. */
+	includeText?: boolean;
+}
+
+/**
+ * Render a Supernote note to one SVG document per page, each showing the
+ * rasterized page image with the recognized handwriting (RTR) text drawn
+ * invisibly on top of it, at the position it was written, so the text can be
+ * found/selected/copied in an SVG viewer.
+ *
+ * SVG has no native multi-page container, so this returns one SVG string per
+ * page rather than a single document — pair each with its page number for
+ * filenames, e.g. `notebook-page-1.svg`.
+ *
+ * Convenience wrapper around `toImage` + `addSvgPage`, all run on the
+ * current thread. To render pages in parallel across Workers, call
+ * `extractPdfPageData` + `toImage` + `encodePng` + `addSvgPage` in each
+ * Worker instead — see the README's PDF section for the equivalent
+ * `extractPdfPageData` pattern (SVG's own `addSvgPage` step can join the
+ * others inside the Worker, since none of it needs the main thread).
+ */
+export async function toSvg(note: ISupernote, options: ToSvgOptions = {}): Promise<string[]> {
+	const { pageNumbers, dpi, includeText } = options;
+	const pages = pageNumbers ? pageNumbers.map((n) => note.pages[n - 1]) : note.pages;
+	const images = await toImage(note, pageNumbers);
+
+	return pages.map((page, i) => addSvgPage(page, images[i], note.pageWidth, note.pageHeight, { dpi, includeText }));
+}

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -1,6 +1,6 @@
 import * as fs from "fs-extra"
 import { encodePng } from "image-js"
-import { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from "../src/pdf"
+import { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage, recognitionCoordinateScale } from "../src/pdf"
 import { toImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
 import { PDFParse } from "pdf-parse"
@@ -149,5 +149,28 @@ describe("pdf", () => {
     for (const word of ["Real", "time", "recognition", "paragraph", "reflow", "together"]) {
       expect(textB.text).toContain(word)
     }
+  })
+
+  test("recognitionCoordinateScale scales proportionally to pageWidth, not a fixed 11.9, for non-Manta devices", () => {
+    // 11.9 only holds at the 1920px-wide reference page (Manta-family
+    // devices); every narrower page (e.g. A5X's default 1404) needs it
+    // scaled down proportionally, or recognized-word positions drift
+    // further from the actual ink the further down the page a word sits.
+    // See https://github.com/philips/supernote-obsidian-plugin/pull/206.
+    expect(recognitionCoordinateScale(1920)).toBeCloseTo(11.9)
+    expect(recognitionCoordinateScale(1404)).toBeCloseTo((1404 * 11.9) / 1920)
+  })
+
+  test("handles a note from a non-Manta device (pageWidth 1404, e.g. A5X) without throwing", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("a5x-2.14.28.note"))
+    expect(sn.pageWidth).toBe(1404)
+
+    const pdfBytes = await toPdf(sn)
+    expect(pdfBytes.byteLength).toBeGreaterThan(0)
+
+    const parser = new PDFParse({ data: pdfBytes })
+    const result = await parser.getText()
+    await parser.destroy()
+    expect(result.text).toContain("Subject")
   })
 })

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -1,0 +1,110 @@
+import * as fs from "fs-extra"
+import { encodePng } from "image-js"
+import { toSvg, addSvgPage } from "../src/svg"
+import { toImage } from "../src/conversion"
+import { SupernoteX } from "../src/parsing"
+import { describe, test, expect } from 'vitest'
+
+function readFileToUint8Array(filePath: string): Promise<Uint8Array> {
+  return new Promise((resolve, reject) => {
+    fs.readFile(`tests/input/${filePath}`, (err, data) => {
+      if (err) {
+        reject(err);
+      } else {
+        resolve(new Uint8Array(data.buffer));
+      }
+    });
+  });
+}
+
+describe("svg", () => {
+  test("generates a searchable SVG with an RTR text overlay", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const svgs = await toSvg(sn)
+    expect(svgs.length).toBe(sn.pages.length)
+    await fs.writeFile("tests/output/rtr.note.0.svg", svgs[0])
+
+    for (const word of ["Real", "time", "recognition", "paragraph", "reflow", "together"]) {
+      expect(svgs.join("")).toContain(word)
+    }
+  })
+
+  test("each page is a well-formed standalone SVG document", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const svgs = await toSvg(sn)
+
+    for (const svg of svgs) {
+      expect(svg.startsWith("<svg ")).toBe(true)
+      expect(svg.endsWith("</svg>")).toBe(true)
+      expect(svg).toContain("<image ")
+      expect(svg).toContain("data:image/png;base64,")
+    }
+  })
+
+  test("handles a note with recognition data from a nomad device", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("nomad-3.15.27-blank-shapes-and-RTR.note"))
+    const svgs = await toSvg(sn)
+    expect(svgs.length).toBeGreaterThan(0)
+    for (const svg of svgs) {
+      expect(svg.length).toBeGreaterThan(0)
+    }
+  })
+
+  test("handles a note with no recognition data without throwing", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("test.note"))
+    const svgs = await toSvg(sn)
+    expect(svgs.length).toBe(sn.pages.length)
+  })
+
+  test("handles a user-uploaded background template and unencodable recognition glyphs", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("moonchild-user-bg-and-bad-glyph.note"))
+    const svgs = await toSvg(sn)
+    expect(svgs.length).toBe(sn.pages.length)
+
+    for (const word of ["Saturn", "Mercury", "Moon", "MAGUS"]) {
+      expect(svgs.join("")).toContain(word)
+    }
+  })
+
+  test("toSvg() produces text equivalent to manual toImage + addSvgPage composition", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+
+    const viaToSvg = await toSvg(sn)
+
+    const images = await toImage(sn)
+    const viaManualComposition = sn.pages.map((page, i) =>
+      addSvgPage(page, images[i], sn.pageWidth, sn.pageHeight),
+    )
+
+    expect(viaToSvg).toEqual(viaManualComposition)
+  })
+
+  test("addSvgPage accepts either an Image or pre-encoded PNG bytes with equivalent output", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const [image] = await toImage(sn, [1])
+
+    const svgFromImage = addSvgPage(sn.pages[0], image, sn.pageWidth, sn.pageHeight)
+    const svgFromBytes = addSvgPage(sn.pages[0], encodePng(image), sn.pageWidth, sn.pageHeight)
+
+    expect(svgFromImage).toBe(svgFromBytes)
+  })
+
+  test("includeText: false omits the recognition text overlay", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const svgs = await toSvg(sn, { includeText: false })
+
+    expect(svgs.join("")).not.toContain("<text ")
+  })
+
+  test("dpi sizes the SVG in physical units without changing the pixel viewBox", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("test.note"))
+
+    const [pixelSvg] = await toSvg(sn, { pageNumbers: [1] })
+    const [dpiSvg] = await toSvg(sn, { pageNumbers: [1], dpi: 300 })
+
+    expect(pixelSvg).toContain(`width="${sn.pageWidth}"`)
+    expect(dpiSvg).toContain(`width="${sn.pageWidth / 300}in"`)
+    expect(pixelSvg).toContain(`viewBox="0 0 ${sn.pageWidth} ${sn.pageHeight}"`)
+    expect(dpiSvg).toContain(`viewBox="0 0 ${sn.pageWidth} ${sn.pageHeight}"`)
+  })
+})

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -1,6 +1,7 @@
 import * as fs from "fs-extra"
 import { encodePng } from "image-js"
 import { toSvg, addSvgPage } from "../src/svg"
+import { recognitionCoordinateScale } from "../src/pdf"
 import { toImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
 import { describe, test, expect } from 'vitest'
@@ -94,6 +95,33 @@ describe("svg", () => {
     const svgs = await toSvg(sn, { includeText: false })
 
     expect(svgs.join("")).not.toContain("<text ")
+  })
+
+  test("positions recognized text proportionally to pageWidth on a non-Manta device (pageWidth 1404, e.g. A5X)", { timeout: 30000 }, async () => {
+    // rtr.note (used elsewhere in this file) is a Manta-family capture
+    // (pageWidth 1920, where the 11.9 reference scale applies directly);
+    // this fixture is the far more common non-Manta case that exposed
+    // https://github.com/philips/supernote-obsidian-plugin/pull/206 -
+    // applying the fixed 11.9 scale here would overscale every box,
+    // landing "Subject" well below its actual line.
+    const sn = new SupernoteX(await readFileToUint8Array("a5x-2.14.28.note"))
+    expect(sn.pageWidth).toBe(1404)
+
+    const [svg] = await toSvg(sn, { pageNumbers: [1] })
+
+    const match = svg.match(/<text x="[^"]*" y="([^"]*)"[^>]*>Subject<\/text>/)
+    expect(match).not.toBeNull()
+    const actualY = Number(match![1])
+
+    // From the raw recognition data: "Subject" has bounding-box
+    // { x: 12.776001, y: 13.224001, width: 25.072002, height: 9.84 },
+    // and addSvgPage positions the baseline at (box.y + box.height) * scale.
+    const scale = recognitionCoordinateScale(sn.pageWidth)
+    const expectedY = (13.224001 + 9.84) * scale
+    const wrongY = (13.224001 + 9.84) * 11.9 // what the old fixed-11.9 bug would have produced
+
+    expect(actualY).toBeCloseTo(expectedY, 1)
+    expect(Math.abs(actualY - wrongY)).toBeGreaterThan(20)
   })
 
   test("dpi sizes the SVG in physical units without changing the pixel viewBox", { timeout: 30000 }, async () => {


### PR DESCRIPTION
## Summary
- Adds `toSvg`/`addSvgPage` (`src/svg.ts`), rendering each page to a standalone SVG document with the page image embedded as a base64 PNG.
- The recognized handwriting (RTR) text is overlaid invisibly at its written position, same idea as `toPdf`, so words are findable/selectable in SVG viewers. Reuses the `RECOGNITION_COORDINATE_SCALE` constant, now exported from `pdf.ts` instead of duplicated.
- `dpi` option sizes the SVG in physical inches; `includeText` toggles the overlay off.
- Unlike PDF assembly, `addSvgPage` touches no non-structured-clone-safe objects, so the whole per-page render pipeline can run inside a Worker.
- README section added alongside the existing PDF one.

## Test plan
- [x] `npm run build` (tsc, no errors)
- [x] `npx eslint .` (clean)
- [x] `npx vitest run` — 57 tests pass across 6 files, including 9 new SVG tests (searchable text, well-formed SVG, edge-case fixtures, `dpi`/`includeText` options, Image-vs-bytes equivalence)
- [x] Manually extracted the embedded PNG from a generated SVG and visually confirmed it renders the page correctly