### PR TITLE
Add smooth upscale option to toImage/toSvg

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,17 @@ const thumbnails = await toImage(note, undefined, { scale: 10 });
 
 Omitting `scale` (or passing `{ scale: 1 }`) renders at full resolution exactly as before.
 
+### Sharper exports: rendering at a higher resolution
+
+Supernote's own export offers a "200%" option that produces a larger raster (e.g. 3840×5120 instead of 1920×2560) for use on high-density displays or print, at the cost of visibly softer pixel-grid edges on ink strokes since there's no extra stroke detail to reveal — it's a resize, not a redraw. Pass `{ upscale }` to `toImage`/`toSvg` for the same effect:
+
+```ts
+const images = await toImage(note, undefined, { upscale: 2 }); // 2x pixel density
+const svgs = await toSvg(note, { upscale: 2 });
+```
+
+`upscale` is a bicubic resize applied after decoding/compositing (any finite number >= 1, not just an integer); it combines with `scale` (applied on top of whatever resolution `scale` decoded at). Unlike a plain resize, edge pixels are premultiplied by alpha before resizing and divided back out after, so anti-aliased edges stay anchored to their own ink color instead of picking up a dark fringe from the fully-transparent background. In `toSvg`, the `viewBox` and recognized-text overlay scale up right along with the raster, and `dpi` (if set) is scaled by the same factor so the physical page size stays put — `upscale` raises pixel density, it doesn't enlarge the page. It's real per-pixel CPU work, worth reserving for an explicit export rather than routine rendering.
+
 ### Reading Atelier `.spd` files
 
 `.spd` files, produced by the Supernote Atelier app, are a different format from `.note` files: a SQLite database of image tiles rather than the custom binary layout `SupernoteX` parses. `SupernoteAtelier.open` reads it (via [sql.js](https://github.com/sql-js/sql.js)) and exposes the tiles per surface (layer — surface names vary per file, e.g. `surface_1` or a `surface_9999` "Reference Layer"), plus best-effort decoded metadata (viewport, canvas size, layer names). Its `.spd` schema and `ls` layer encoding aren't officially documented; the reverse-engineered details are noted in [src/atelier.ts](./src/atelier.ts).

--- a/src/conversion.ts
+++ b/src/conversion.ts
@@ -106,6 +106,56 @@ export function compositeImages(sourceImage: Image, destinationImage: Image) {
 	}
 }
 
+/** Bicubic-resizes an 8-bit RGBA image up by `factor`, without the color
+ * fringing a naive resize would produce at ink/transparent edges:
+ * flattenToWhite()'s own comment below notes background pixels are packed
+ * as black at alpha 0, since nothing normally looks at their color. A plain
+ * resize interpolates color and alpha channels independently, so it *would*
+ * look at that stored black and blend it into partially-transparent edge
+ * pixels - darkening non-black ink (white highlighter, gray marker) right
+ * where anti-aliasing should be smoothing it, not tinting it. Premultiplying
+ * by alpha before the resize and dividing it back out after (standard
+ * "premultiplied alpha" compositing) keeps interpolated color anchored to
+ * the actual ink color instead of the meaningless color underneath it. */
+export function upscaleImage(image: Image, factor: number): Image {
+	const { width, height, data, channels, bitDepth } = image.getRawImage();
+	if (bitDepth !== 8 || channels !== 4) {
+		throw new Error('upscale only supports 8-bit RGBA images.');
+	}
+
+	const premultiplied = new Uint8Array(data.length);
+	for (let i = 0; i < data.length; i += 4) {
+		const alpha = data[i + 3];
+		premultiplied[i] = Math.round((data[i] * alpha) / 255);
+		premultiplied[i + 1] = Math.round((data[i + 1] * alpha) / 255);
+		premultiplied[i + 2] = Math.round((data[i + 2] * alpha) / 255);
+		premultiplied[i + 3] = alpha;
+	}
+
+	const resized = new Image(width, height, { colorModel: ImageColorModel.RGBA, data: premultiplied }).resize({
+		xFactor: factor,
+		yFactor: factor,
+		preserveAspectRatio: false,
+		interpolationType: 'bicubic',
+	});
+
+	const raw = resized.getRawImage();
+	const out = new Uint8Array(raw.data.length);
+	for (let i = 0; i < raw.data.length; i += 4) {
+		const alpha = raw.data[i + 3];
+		if (alpha === 0) {
+			out[i] = out[i + 1] = out[i + 2] = 0;
+		} else {
+			out[i] = Math.min(255, Math.round((raw.data[i] * 255) / alpha));
+			out[i + 1] = Math.min(255, Math.round((raw.data[i + 1] * 255) / alpha));
+			out[i + 2] = Math.min(255, Math.round((raw.data[i + 2] * 255) / alpha));
+		}
+		out[i + 3] = alpha;
+	}
+
+	return new Image(raw.width, raw.height, { colorModel: ImageColorModel.RGBA, data: out });
+}
+
 /** Flattens an image with an alpha channel onto an opaque white background,
  * producing a plain image (RGB, or GREY for a GREYA source) with no alpha
  * channel at all - for a destination (e.g. a PDF page, see
@@ -152,6 +202,20 @@ export interface ToImageOptions {
 	 * on memory-constrained devices, see
 	 * https://github.com/philips/supernote-typescript/issues/40. */
 	scale?: number;
+	/** Smooth upscale factor (finite number >= 1, default 1 = no upscaling).
+	 * Applied via upscaleImage() as a bicubic resize *after* decoding/
+	 * compositing, not by decoding at a higher resolution - Supernote's
+	 * layers are fixed-resolution rasters (decodeAtScale samples them, it
+	 * doesn't invent detail), so there's nothing extra to recover, only
+	 * visible stair-stepping on stroke edges to soften. Mirrors Ratta's own
+	 * "200%" export option; combines with `scale` (applied on top of
+	 * whatever resolution `scale` decoded at), see
+	 * https://github.com/philips/supernote-obsidian-plugin/issues/212.
+	 * The bicubic resize is real per-pixel CPU work (~10s for a single
+	 * full-resolution Manta page at `upscale: 1.5` on a dev laptop) -- fine
+	 * for an on-demand export, not something to run on every page of a
+	 * scrolling viewer. */
+	upscale?: number;
 }
 
 /**
@@ -165,6 +229,10 @@ export function toImage(note: IRenderableNote, pageNumbers?: number[], options?:
 	const scale = options?.scale ?? 1;
 	if (!Number.isInteger(scale) || scale < 1) {
 		throw new RangeError(`scale must be a positive integer, received ${scale}`);
+	}
+	const upscale = options?.upscale ?? 1;
+	if (!Number.isFinite(upscale) || upscale < 1) {
+		throw new RangeError(`upscale must be a number >= 1, received ${upscale}`);
 	}
 	const outWidth = Math.ceil(note.pageWidth / scale);
 	const outHeight = Math.ceil(note.pageHeight / scale);
@@ -222,7 +290,7 @@ export function toImage(note: IRenderableNote, pageNumbers?: number[], options?:
 				compositeImages(images[i], output);
 			}
 
-			return output;
+			return upscale === 1 ? output : upscaleImage(output, upscale);
 		}),
 	);
 }

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -136,6 +136,16 @@ export interface ToSvgOptions {
 	dpi?: number;
 	/** See `AddSvgPageOptions.includeText`. */
 	includeText?: boolean;
+	/** See `ToImageOptions.upscale`. The resulting SVG's pixel `viewBox` (and
+	 * so the recognized-text overlay's coordinate space, via
+	 * `recognitionCoordinateScale`) scales up right along with the embedded
+	 * raster - both are sized off the actual produced image, not off
+	 * `note.pageWidth`/`pageHeight`, so text stays aligned to the ink at any
+	 * upscale factor. When `dpi` is also set, it's scaled by the same factor
+	 * so the physical `width`/`height` (inches) stay put - `upscale` raises
+	 * pixel density for a sharper render at the same physical size (like a
+	 * "retina" image), it doesn't enlarge the page. */
+	upscale?: number;
 }
 
 /**
@@ -156,9 +166,16 @@ export interface ToSvgOptions {
  * others inside the Worker, since none of it needs the main thread).
  */
 export async function toSvg(note: ISupernote, options: ToSvgOptions = {}): Promise<string[]> {
-	const { pageNumbers, dpi, includeText } = options;
+	const { pageNumbers, dpi, includeText, upscale = 1 } = options;
 	const pages = pageNumbers ? pageNumbers.map((n) => note.pages[n - 1]) : note.pages;
-	const images = await toImage(note, pageNumbers);
+	const images = await toImage(note, pageNumbers, { upscale });
 
-	return pages.map((page, i) => addSvgPage(page, images[i], note.pageWidth, note.pageHeight, { dpi, includeText }));
+	// Scale dpi along with the raster so widthAttr/heightAttr (pageWidth /
+	// dpi) come out the same physical size regardless of upscale - see
+	// ToSvgOptions.upscale's doc comment.
+	const effectiveDpi = dpi ? dpi * upscale : dpi;
+
+	return pages.map((page, i) =>
+		addSvgPage(page, images[i], images[i].width, images[i].height, { dpi: effectiveDpi, includeText }),
+	);
 }

--- a/tests/conversion.test.ts
+++ b/tests/conversion.test.ts
@@ -2,7 +2,7 @@ import * as fs from "fs-extra"
 import * as imagejs from "image-js"
 import { Image, ImageColorModel } from "image-js"
 import { describe, test, expect } from 'vitest'
-import { toImage, RattaRLEDecoder, flattenToWhite } from "../src/conversion"
+import { toImage, RattaRLEDecoder, flattenToWhite, upscaleImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
 
 function readFileToUint8Array(filePath: string): Promise<Uint8Array> {
@@ -171,5 +171,77 @@ describe("toImage scale option", () => {
     // toImage validates scale synchronously (before ever returning a
     // promise), so this throws immediately rather than rejecting.
     expect(() => toImage(sn, [1], { scale: 0 })).toThrow(RangeError);
+  })
+})
+
+describe("toImage upscale option", () => {
+  test("renders a page bicubic-upscaled by a non-integer factor", { timeout: 60000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"));
+    const upscale = 1.5;
+    const images = await toImage(sn, [1], { upscale });
+    expect(images.length).toBe(1);
+    expect(images[0].width).toBe(Math.round(sn.pageWidth * upscale));
+    expect(images[0].height).toBe(Math.round(sn.pageHeight * upscale));
+    await imagejs.writeSync(`tests/output/upscaled-rtr.png`, images[0]);
+  })
+
+  test("upscale: 1 (default) still matches the previous full-resolution output size", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("test.note"));
+    const [withoutOptions] = await toImage(sn, [1]);
+    const [withUpscale1] = await toImage(sn, [1], { upscale: 1 });
+    expect(withUpscale1.width).toBe(withoutOptions.width);
+    expect(withUpscale1.height).toBe(withoutOptions.height);
+  })
+
+  test("combines with scale: downsamples at decode time, then upscales the result", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"));
+    const scale = 4;
+    const upscale = 2;
+    const images = await toImage(sn, [1], { scale, upscale });
+    const decodedWidth = Math.ceil(sn.pageWidth / scale);
+    const decodedHeight = Math.ceil(sn.pageHeight / scale);
+    expect(images[0].width).toBe(Math.round(decodedWidth * upscale));
+    expect(images[0].height).toBe(Math.round(decodedHeight * upscale));
+  })
+
+  test("rejects an upscale factor below 1", async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("test.note"));
+    expect(() => toImage(sn, [1], { upscale: 0.5 })).toThrow(RangeError);
+    expect(() => toImage(sn, [1], { upscale: NaN })).toThrow(RangeError);
+  })
+})
+
+describe("upscaleImage", () => {
+  test("does not darken opaque white pixels toward the transparent background's stored black", () => {
+    // A single fully-opaque white pixel surrounded by fully-transparent
+    // pixels. Fully-transparent RGBA is packed as black-at-alpha-0
+    // throughout this codebase (see flattenToWhite()'s own comment on why),
+    // so a resize that interpolates color and alpha independently would
+    // blend that stored black into the anti-aliased edge, darkening it -
+    // exactly what premultiplying by alpha before resizing is meant to
+    // avoid.
+    const width = 3;
+    const height = 3;
+    const data = new Uint8Array(width * height * 4); // defaults to all zeros: transparent black
+    const centerIndex = (1 * width + 1) * 4;
+    data[centerIndex] = 255;
+    data[centerIndex + 1] = 255;
+    data[centerIndex + 2] = 255;
+    data[centerIndex + 3] = 255;
+
+    const image = new Image(width, height, { colorModel: ImageColorModel.RGBA, data });
+    const upscaled = upscaleImage(image, 4);
+
+    const { data: outData } = upscaled.getRawImage();
+    for (let i = 0; i < outData.length; i += 4) {
+      const alpha = outData[i + 3];
+      if (alpha === 0) continue;
+      // A premultiplied-alpha resize keeps color anchored to the source
+      // pixel's own color (white) at every alpha level; a naive resize
+      // would instead pull it toward black as alpha falls off near the edge.
+      expect(outData[i]).toBe(255);
+      expect(outData[i + 1]).toBe(255);
+      expect(outData[i + 2]).toBe(255);
+    }
   })
 })

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -198,6 +198,43 @@ describe("svg", () => {
     expect(svgs[2]).not.toContain(">ERASER</text>")
   })
 
+  test("upscale grows the embedded raster and the viewBox/text overlay together", { timeout: 60000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("rtr.note"))
+    const upscale = 2
+
+    const [nativeSvg] = await toSvg(sn, { pageNumbers: [1] })
+    const [upscaledSvg] = await toSvg(sn, { pageNumbers: [1], upscale })
+    await fs.writeFile("tests/output/rtr.note.0.upscaled.svg", upscaledSvg)
+
+    const expectedWidth = Math.round(sn.pageWidth * upscale)
+    const expectedHeight = Math.round(sn.pageHeight * upscale)
+    expect(upscaledSvg).toContain(`viewBox="0 0 ${expectedWidth} ${expectedHeight}"`)
+    expect(upscaledSvg).toContain(`width="${expectedWidth}"`)
+    expect(upscaledSvg).toContain(`height="${expectedHeight}"`)
+
+    // The recognized-text overlay's coordinates scale with the viewBox, so
+    // a word's baseline y should move by ~upscale, not stay put.
+    const nativeMatch = nativeSvg.match(/<text x="[^"]*" y="([^"]*)"[^>]*>Real<\/text>/)
+    const upscaledMatch = upscaledSvg.match(/<text x="[^"]*" y="([^"]*)"[^>]*>Real<\/text>/)
+    expect(nativeMatch).not.toBeNull()
+    expect(upscaledMatch).not.toBeNull()
+    const nativeY = Number(nativeMatch![1])
+    const upscaledY = Number(upscaledMatch![1])
+    expect(upscaledY).toBeCloseTo(nativeY * upscale, 0)
+  })
+
+  test("upscale scales dpi along with it, keeping the physical width/height constant", { timeout: 30000 }, async () => {
+    const sn = new SupernoteX(await readFileToUint8Array("test.note"))
+    const dpi = 300
+    const upscale = 2
+
+    const [nativeSvg] = await toSvg(sn, { pageNumbers: [1], dpi })
+    const [upscaledSvg] = await toSvg(sn, { pageNumbers: [1], dpi, upscale })
+
+    const widthMatch = (svg: string) => svg.match(/width="([\d.]+)in"/)
+    expect(widthMatch(upscaledSvg)![1]).toBe(widthMatch(nativeSvg)![1])
+  })
+
   test("dpi sizes the SVG in physical units without changing the pixel viewBox", { timeout: 30000 }, async () => {
     const sn = new SupernoteX(await readFileToUint8Array("test.note"))
 


### PR DESCRIPTION
## Summary
- Adds `upscale` to `ToImageOptions`/`ToSvgOptions`: a bicubic resize applied after decode/composite, mirroring the existing `scale` (downsample) option but in the other direction — matches Ratta's own "200%" export lever.
- Since Supernote's stroke layers are fixed-resolution rasters (no vector detail to recover), this is a resize, not a redraw — reduces visible stair-stepping when displayed/exported larger, at the cost of real per-pixel CPU work (documented in the doc comment).
- Premultiplies alpha before resizing and divides it back out after, so anti-aliased edges stay anchored to their own ink color instead of picking up a dark fringe from the fully-transparent background (which is stored as black-at-alpha-0 throughout this codebase — see `flattenToWhite`'s comment). Covered by a dedicated unit test with a hand-crafted white-on-transparent pixel.
- In `toSvg`, the `viewBox` and recognized-text overlay scale up with the raster (derived from the actual produced image, not `note.pageWidth`/`pageHeight`), and `dpi` is scaled by the same factor so physical page size stays put — `upscale` raises pixel density, it doesn't enlarge the page.

Addresses the scaling half of [philips/supernote-obsidian-plugin#212](https://github.com/philips/supernote-obsidian-plugin/issues/212) (the transparency/invert half is a CSS `filter: invert(1)` trick on the consuming site, not a library change — see [comment](https://github.com/philips/supernote-obsidian-plugin/issues/212#issuecomment-5220652106)).

## Test plan
- [x] `npx vitest run` — 71/71 passing, including new `toImage upscale option`, `upscaleImage`, and `toSvg` upscale tests
- [x] `npx tsc --noEmit` — clean
- [x] Manually inspected `tests/output/upscaled-rtr.png` and `tests/output/rtr.note.0.upscaled.svg`