### PR TITLE
Cap vitest to 2 threaded workers to cut test-run memory (~32%)

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,5 +5,22 @@ export default defineConfig({
 	test: {
 		include: ['tests/**/*.test.ts'],
 		environment: 'node',
+		// Vitest's own default (pool: 'forks', one worker per CPU core) peaked
+		// at ~1.1GB RSS across 4 worker processes measured on a 4-core/7.6GB
+		// host running this suite -- each worker is a full separate Node
+		// process re-loading every dependency (image-js, sql.js's WASM
+		// build, pdf-lib, fontkit) from scratch. That's fine with room to
+		// spare here, but has been reported to OOM on more memory-constrained
+		// hosts. Switching to the 'threads' pool (workers share the engine
+		// instead of each being a full separate process) and capping at 2
+		// workers cut measured peak RSS to ~770MB (-32%) with no wall-time
+		// cost on this same host (workers beyond 2 mostly added contention,
+		// not real parallelism, once 4 processes were competing for 4 cores
+		// alongside everything else already running on it) -- see issue
+		// investigation for the full before/after numbers. Override with
+		// `--pool=forks --maxWorkers=N` on a host where memory isn't the
+		// constraint and more parallelism is worth it.
+		pool: 'threads',
+		maxWorkers: 2,
 	},
 });


### PR DESCRIPTION
## Summary
- Reported: `npm test` reliably OOMs on the reporter's host.
- Measured actual memory (sampling system-wide available memory + summed node process RSS every 2s) rather than guessing, running the full suite under a few different `vitest` pool/worker configurations on a 4-core/7.6GB host:

| config | peak RSS | wall time |
|---|---|---|
| `pool=forks, maxWorkers=4` (vitest's own default) | ~1130MB | 112s |
| `pool=forks, maxWorkers=2` | ~858MB | 105s |
| `pool=forks, maxWorkers=1` | ~593MB | 137s |
| **`pool=threads, maxWorkers=2`** (this PR) | **~769MB** | **106s** |

- Each of vitest's default `forks` workers is a full separate Node process re-loading every dependency (image-js, sql.js's WASM build, pdf-lib, fontkit) from scratch — with 4 of them running this repo's image/PDF-heavy tests, that's where the memory goes.
- Switching to the `threads` pool (workers share the engine instead of each being a separate OS process) and capping at 2 workers cuts peak RSS by ~32% from vitest's default, with no wall-time cost on this host — beyond 2 workers was mostly adding contention rather than real parallelism once several processes were competing for the same 4 cores.
- `npm test` (no flags) now runs at this profile by default. Override with `--pool=forks --maxWorkers=N` on a host where memory isn't the constraint and more parallelism is worth it.

## Test plan
- [x] `npm test` — 71/71 pass on this branch
- [x] Verified peak memory with each config above via a sampling monitor (system `free` + summed node RSS every 2s) rather than guessing