### PR TITLE
Decode StrokeConfig offset 40 as a record-class field

### DIFF
--- a/plans/vector-format-spec.md
+++ b/plans/vector-format-spec.md
@@ -88,7 +88,7 @@ tool/color/width-isolated pages, `headings-and-marker.note`,
 | 28 | `page_num` (u32) | **confirmed** — 1-indexed page number, matches the containing page exactly in every fixture |
 | 32 | `unk_3` | reads `0` everywhere |
 | 36 | `unk_4` | reads `0` everywhere |
-| 40 | `unk_5` | **confirmed** always `5000` (matches snlib) |
+| 40 | `record_class` (i32) | **decoded** — not the constant `5000` snlib documents. It states what the record *is*: `5000` ink, `0` two-point-derived geometry, `-1`/`-2`/`-4` eraser gesture, `-5` lasso path. See below. |
 | 44 | `stroke_layer` (u32) | **confirmed** — `test.note` has real `LAYER1` content; its strokes read `1` here, `MAINLAYER` strokes read `0` (0-indexed ignoring background, exactly as snlib says) |
 | 48 | `stroke_kind` (52-byte C string) | **confirmed** — see below; Ratta's own name is `predictName` (Part 1.4) |
 | 100 | `bounding_tl` (i32 x, i32 y) | **decoded** — see below; Ratta's name `upLeftPoint` |
@@ -358,6 +358,46 @@ Findings, each confirmed against device ground truth:
    threshold can be right for all of them. Clipping each stroke to the
    rendered ink mask, rather than deciding per stroke, is what would remove
    the last threshold entirely.
+
+### `record_class` (offset 40) — what a record *is*, and what it still won't tell you
+
+snlib documents offset 40 as `unk_5`, "only ever seen `5000`", and this
+document repeated that. It is wrong: `5000` is the value for real ink, and
+ink is ~97% of records. Every record in every fixture (2,544 across all
+device families and firmware here) falls into one of four groups:
+
+| Value | Records | What |
+|---|---|---|
+| `5000` | 2457 | real ink — every pen, every colour, including white |
+| `0` | 22 | geometry derived from two points: a Heading background (`"0001"`), a link-tag box (`"0000"`), or a ruler line (`"straightLine"`) |
+| `-1`, `-2`, `-4` | 46 | an eraser gesture (three tool modes/eras) |
+| `-5` | 19 | a lasso selection path |
+
+Two things make this worth having. `-5` holds **every** `pen === 4` record
+and nothing else, so `src/strokes.ts` now excludes lasso paths on this
+field instead of on the pen id — durable against firmware reusing ids
+across tools, which it demonstrably does (`pen === 1` is both the older ink
+pen and the Nomad-era eraser). And `0` is a single uniform marker for the
+two-point-derived records that have caused real bugs when mistaken for
+ordinary strokes — the `"straightLine"` ruler-line case in particular.
+
+**What it does not do is tell you whether an erase actually erased
+anything**, which is what it was investigated for. `erase.note`, which
+exercises every erase mechanism, carries genuine erasers at `-4`; and
+`nomad-3.26.40-link-tag-3p.note` page 3's `-4` records sit on top of fully
+visible keyword text having erased nothing. Same class, opposite outcome.
+The field identifies the *tool*, never the *result*.
+
+So the device's own taxonomy (`TRAIL_ERASE_AREA` / `ERASE_LINE_COLOR_VALUE`
+/ `CLEAN SCREEN` / region selection / `ERASER select`, Part 1.4) still
+implies a discriminator exists, and it is still not found — see the open
+questions. Ruled out so far: `disableAreaList`, `point_contour`,
+`flag_draw`, and now `record_class`. A plausible remaining reading is that
+there is nothing to find in the record at all, and the distinction is
+positional — the app decides by replaying trails in order, so a gesture's
+meaning may depend on what the *preceding* records did (a lasso immediately
+before an eraser is a select-then-delete; the same eraser alone is a drag).
+Nothing has tested that yet.
 
 ### `point_contour` — decoded: the device's own rendered outline
 
@@ -1108,12 +1148,21 @@ pass; the findings are folded into the sections above. In brief:
    `strokeLen` rather than parsing the tail. Nothing needs them.
 9. **The erase-vs-select discriminator** — the app distinguishes
    `TRAIL_ERASE_AREA`, `ERASE_LINE_COLOR_VALUE`, `CLEAN SCREEN`, region
-   selection and `ERASER select` (Part 1.4), so the record must carry
-   something this repo hasn't found. Resolving it is what would let the
-   erase replay work on `nomad-3.26.40-link-tag-3p.note` page 3 and remove
-   the last raster dependency in the erase path. `disableAreaList` is ruled
-   out; the named-but-unassigned `StrokeConfig` scalars are the remaining
-   candidates.
+   selection and `ERASER select` (Part 1.4), so something must carry the
+   distinction. Resolving it is what would let the erase replay work on
+   `nomad-3.26.40-link-tag-3p.note` page 3 and remove the last raster
+   dependency in the erase path.
+
+   Ruled out: `disableAreaList`, `point_contour`, `flag_draw`, and
+   `record_class` (offset 40 — it gives the *tool*, not the outcome; see its
+   section above). The named-but-unassigned `StrokeConfig` scalars remain
+   candidates, but the negative results are piling up, and the more likely
+   reading now is that **the distinction isn't in the record at all**. The
+   app replays trails in order, so a gesture's meaning can depend on what
+   preceded it — a lasso immediately before an eraser is a
+   select-then-delete, the same eraser alone is a drag. Testing that
+   ordering hypothesis is cheaper than continuing to search fields, and
+   should come first.
 10. **`m_trailStatus`'s codes** — `-4`/`-16`/`-99` are a status enum, not a
     boolean (Part 1.4). Decoding them may subsume question 9.
 

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -164,23 +164,6 @@ const LINK_TAG_STROKE_KIND = '0000';
  * (see `IStroke.isFilledRect`). */
 const FILLED_RECT_STROKE_KIND = '0001';
 
-/** `pen` id of a lasso/selection *path* record -- the loop a user draws to
- * select content (then delete it, move it, or turn it into a
- * Keyword/Tag) -- not ink, and never rendered by the device. Confirmed
- * against every fixture that has one (all reading `color: 0`,
- * `thickness: 200`, and frequently recorded as two byte-identical
- * consecutive records): `erase.note` (a lasso-select-then-delete; the loop
- * is absent from both the device raster and `erase.pdf`, Supernote's own
- * export), `nomad-3.26.40-link-tag-3p.note` page 3 (keyword/tag-creation
- * selections around fully-visible words -- rendering these drew phantom
- * black circles around the text), and `unknown-color.note` (a path with ~0%
- * presence in the page's own rendered ink). Excluded unconditionally, like
- * `LINK_TAG_STROKE_KIND`: whatever the selection *did* (delete vs. move vs.
- * keyword -- not recoverable from this record, see
- * plans/vector-format-spec.md's erase-records section), the loop itself is
- * never visible content. */
-const LASSO_PEN_ID = 4;
-
 /** Byte layout of the fixed-size header (`StrokeConfig` in
  * https://github.com/Walnut356/snlib) every stroke record starts with.
  * Offsets confirmed against real fixtures: `DOC_KIND_OFFSET` is exactly
@@ -207,7 +190,61 @@ const STROKE_CONFIG = {
 	 * `superNoteNote`-relative offset instead of `StrokeConfig`'s own). */
 	SCREEN_HEIGHT_OFFSET: 128,
 	DOC_KIND_OFFSET: 136,
+	/** See `RECORD_CLASS`. Documented as a constant `5000` by
+	 * https://github.com/Walnut356/snlib (as `unk_5`) -- it isn't. */
+	RECORD_CLASS_OFFSET: 40,
 	SIZE: 208,
+} as const;
+
+/** What kind of thing a stroke record *is*, read as an `i32` from
+ * `STROKE_CONFIG.RECORD_CLASS_OFFSET`. snlib documents this field as a
+ * constant `5000` (`unk_5`); it isn't. Every record in every fixture (2,544
+ * of them, across every device family and firmware here) falls into exactly
+ * one of four groups:
+ *
+ * | Value | Records | What |
+ * |---|---|---|
+ * | `5000` | 2457 | real ink -- every pen, every color, including white |
+ * | `0` | 22 | geometry derived from two points: a Heading background (`"0001"`), a link-tag box (`"0000"`), or a ruler line (`"straightLine"`) |
+ * | `-1`, `-2`, `-4` | 46 | an eraser gesture (three tool modes/eras) |
+ * | `-5` | 19 | a lasso selection path |
+ *
+ * The eraser/lasso split is exact: `-5` holds every `pen === 4` record and
+ * nothing else, which is why it can replace that test. It is also the
+ * durable form of it -- firmware reuses pen ids across tools (`pen === 1`
+ * is both the older ink pen and the Nomad-era eraser), whereas this field
+ * states the record's kind directly.
+ *
+ * **What this field does not do** is say whether an erase gesture actually
+ * erased anything. That was the hope -- Supernote's own engine classifies
+ * trails as `TRAIL_ERASE_AREA` / `ERASE_LINE_COLOR_VALUE` / `CLEAN SCREEN`
+ * / `this is region selection trail` / `trail ERASER select:` as it
+ * replays them, so some discriminator exists -- but it is not this one.
+ * `erase.note`, which exercises every erase mechanism, carries genuine
+ * erasers at `-4`, while `nomad-3.26.40-link-tag-3p.note` page 3's `-4`
+ * records sit on top of fully visible keyword text and erased nothing. Same
+ * class, opposite outcome. So this identifies the *tool*, never the
+ * *result*, and a geometric erase replay still cannot be driven from it. */
+const RECORD_CLASS = {
+	INK: 5000,
+	/** A lasso/selection *path* -- the loop a user draws to select content
+	 * (then delete it, move it, or turn it into a Keyword/Tag). Not ink, and
+	 * never rendered by the device, so it is excluded unconditionally like
+	 * `LINK_TAG_STROKE_KIND`: whatever the selection *did* is not recoverable
+	 * from the record (see plans/vector-format-spec.md's erase-records
+	 * section), but the loop itself is never visible content either way.
+	 *
+	 * Holds exactly the records that previously matched `pen === 4` -- all
+	 * reading `color: 0`, `thickness: 200`, and frequently recorded as two
+	 * byte-identical consecutive records. That those are never rendered was
+	 * established against every fixture that has one: `erase.note` (a
+	 * lasso-select-then-delete; the loop is absent from both the device
+	 * raster and `erase.pdf`, Supernote's own export),
+	 * `nomad-3.26.40-link-tag-3p.note` page 3 (keyword/tag-creation
+	 * selections around fully-visible words -- rendering these drew phantom
+	 * black circles around the text), and `unknown-color.note` (a path with
+	 * ~0% presence in the page's own rendered ink). */
+	LASSO: -5,
 } as const;
 
 /** Sizes of the two fixed-layout sections that sit between `epa_grays` and
@@ -230,6 +267,8 @@ interface RawStroke {
 	strokeKind: string;
 	screenHeight: number;
 	points: [number, number][]; // raw (y, x) pairs, undivided device units
+	/** See `RECORD_CLASS`. */
+	recordClass: number;
 	/** See `IStroke.eraserTouched`. */
 	eraseMark: number;
 	/** Already in page-pixel space -- unlike `points`, these need no
@@ -313,6 +352,7 @@ function tryParseStroke(
 	const strokeKind = readFixedCString(view, pos + STROKE_CONFIG.STROKE_KIND_OFFSET, STROKE_CONFIG.STROKE_KIND_SIZE);
 	const screenHeight = view.getUint32(pos + STROKE_CONFIG.SCREEN_HEIGHT_OFFSET, true);
 	if (screenHeight === 0) return null;
+	const recordClass = view.getInt32(pos + STROKE_CONFIG.RECORD_CLASS_OFFSET, true);
 
 	let p = pos + STROKE_CONFIG.SIZE;
 
@@ -341,14 +381,15 @@ function tryParseStroke(
 	// epa_points (8), epa_grays (4) -- all length-prefixed, all skipped
 	// wholesale; Section1 (and so the erase mark) begins immediately after.
 	for (const elementSize of [2, 4, 1, 8, 4]) {
-		if (p + 4 > strokeEnd) return { pen, color, thickness, strokeKind, screenHeight, points, eraseMark: 0 };
+		if (p + 4 > strokeEnd)
+			return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark: 0 };
 		p += 4 + view.getUint32(p, true) * elementSize;
 	}
 
 	const eraseMark = p + 4 <= strokeEnd ? view.getInt32(p, true) : 0;
 	const contour = includeContours ? readContour(view, byteLength, p, strokeEnd) : undefined;
 
-	return { pen, color, thickness, strokeKind, screenHeight, points, eraseMark, contour };
+	return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark, contour };
 }
 
 /**
@@ -423,10 +464,11 @@ function tryParseStroke(
  * comment: a link-tag indicator box, not ink, confirmed against
  * `nomad-3.26.40-link-tag-3p.note`'s own footer `LINK_*` metadata.
  *
- * Strokes whose `pen` is `4` are excluded unconditionally too -- see
- * `LASSO_PEN_ID`'s doc comment: the loop drawn to lasso-select content
- * (for deletion, moving, or Keyword/Tag creation), never rendered by the
- * device.
+ * Select gestures are excluded unconditionally too -- the loop drawn to
+ * lasso-select content (for deletion, moving, or Keyword/Tag creation),
+ * never rendered by the device. These are identified by the record-class
+ * field rather than by pen id; see `RECORD_CLASS`, which is also what tells
+ * a select apart from an erase when the two are otherwise identical.
  *
  * Returns `[]` if `totalPathBuffer` is `null`, too short to hold a single
  * stroke, or its layout isn't recognized (e.g. a genuinely blank page, or a
@@ -471,7 +513,12 @@ export function parseStrokes(
 		const raw = tryParseStroke(view, byteLength, strokeStart, strokeEnd, options.includeContours === true);
 		const isEraser = raw?.color === ERASER_COLOR;
 		const isLinkTag = raw?.strokeKind === LINK_TAG_STROKE_KIND;
-		const isLassoPath = raw?.pen === LASSO_PEN_ID;
+		// Replaces an earlier `pen === 4` test: this drops exactly the same
+		// records on every fixture (verified -- `RECORD_CLASS.LASSO` holds
+		// every pen=4 record and nothing else), but keys on the field that
+		// states the record's kind instead of on a pen id, which firmware
+		// reuses across tools.
+		const isLassoPath = raw?.recordClass === RECORD_CLASS.LASSO;
 		if (raw && !isLinkTag && !isLassoPath && (!isEraser || options.includeErasers)) {
 			const scale = raw.screenHeight / pageHeight;
 			strokes.push({

--- a/tests/strokes.test.ts
+++ b/tests/strokes.test.ts
@@ -444,4 +444,49 @@ describe("parseStrokes", () => {
       expect(withContour / total).toBeGreaterThan(0.95);
     });
   });
+
+  describe("record class (StrokeConfig offset 40)", () => {
+    test("identifies lasso paths exactly, matching the pen id it replaced", async () => {
+      // The lasso exclusion now keys on the record-class field rather than
+      // on `pen === 4`, because firmware reuses pen ids across tools. This
+      // pins the equivalence that made the swap safe: across every fixture,
+      // the set of records the field calls a lasso is precisely the set of
+      // pen=4 records -- no ink accidentally dropped, no loop kept.
+      const RECORD_CLASS_OFFSET = 40, LASSO = -5, CONFIG_SIZE = 208;
+      const fixtures = fs.readdirSync("tests/input").filter((name) => name.endsWith(".note")).sort();
+      let lassoByClass = 0, lassoByPen = 0, ink = 0, disagreements = 0;
+
+      for (const fixture of fixtures) {
+        const sn = new SupernoteX(await readFileToUint8Array(fixture));
+        for (const page of sn.pages) {
+          const buf = page.totalPathBuffer;
+          if (!buf || buf.length < 16) continue;
+          const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+          const count = view.getUint32(0, true);
+          if (!count || count > 1_000_000) continue;
+          let pos = 4;
+          for (let i = 0; i < count; i++) {
+            if (pos + 4 > buf.length) break;
+            const len = view.getUint32(pos, true);
+            const start = pos + 4;
+            if (!len || len < CONFIG_SIZE || start + len > buf.length) break;
+            pos = start + len;
+            const byClass = view.getInt32(start + RECORD_CLASS_OFFSET, true) === LASSO;
+            const byPen = view.getUint32(start, true) === 4;
+            if (byClass) lassoByClass++;
+            if (byPen) lassoByPen++;
+            if (byClass !== byPen) disagreements++;
+            if (view.getInt32(start + RECORD_CLASS_OFFSET, true) === 5000) ink++;
+          }
+        }
+      }
+
+      expect(disagreements).toBe(0);
+      expect(lassoByClass).toBe(lassoByPen);
+      expect(lassoByClass).toBeGreaterThan(0);
+      // The field is not the constant 5000 snlib documents it as, but it is
+      // 5000 for the overwhelming majority -- real ink.
+      expect(ink).toBeGreaterThan(2000);
+    });
+  });
 });


### PR DESCRIPTION
Work on #70. **It does not close it** — the field turned out not to be the erase-vs-select discriminator. It is worth having anyway, and the negative result is worth recording so it isn't re-tried.

## The correction

snlib documents `StrokeConfig` offset 40 as `unk_5`, "only ever seen `5000`", and `plans/vector-format-spec.md` repeated that. It holds only because real ink is ~97% of records. Across all 2,544 records in every fixture the field takes four groups:

| Value | Records | What |
|---|---|---|
| `5000` | 2457 | real ink — every pen, every colour, including white |
| `0` | 22 | geometry derived from two points: Heading background (`"0001"`), link-tag box (`"0000"`), ruler line (`"straightLine"`) |
| `-1`, `-2`, `-4` | 46 | an eraser gesture (three tool modes/eras) |
| `-5` | 19 | a lasso selection path |

## What ships

`parseStrokes` excludes lasso paths on this field instead of on `pen === 4`. The two select exactly the same records on every fixture, so it is behaviour-preserving — but it keys on the field that states the record's kind rather than on a pen id, and firmware demonstrably reuses those across tools (`pen === 1` is both the older ink pen and the Nomad-era eraser). A test pins the equivalence, because a false positive here silently deletes visible ink.

`0` is also now a single uniform marker for the two-point-derived records that have caused real bugs when mistaken for ordinary strokes — the `"straightLine"` ruler-line case in particular.

## Why it isn't the discriminator, and a wrong turn worth flagging

My first pass concluded `-4`/`-5` meant "select" and `-1`/`-2` meant "erase". That was wrong on both the method and the answer.

The outcome-classifier behind it ran against the **main checkout's** `tests/input`, which sits on an older branch and predates `erase.note`, `erase-colors.note`, `caligraphy.note` and others. On the fixtures it did see, every `-4` record happened to have erased nothing, so the split looked clean. The repo's own test suite caught it immediately (`erase.note` returned 16 erasers where 18 were expected).

Re-run against the real fixture set, the picture is unambiguous: `erase.note`, which exercises every erase mechanism, carries genuine erasers at `-4`; `nomad-3.26.40-link-tag-3p.note` page 3's `-4` records sit on top of fully visible keyword text having erased nothing. Same class, opposite outcome. **The field identifies the tool, never the result.** Both `RECORD_CLASS`'s doc comment and the spec section say so explicitly.

## Where that leaves #70

Ruled out now: `disableAreaList`, `point_contour`, `flag_draw`, and `record_class`. The device's taxonomy (Part 1.4) still implies a distinction exists somewhere.

The more likely reading, added to the open questions: **it may not be in the record at all.** The app replays trails in order, so a gesture's meaning can depend on what preceded it — a lasso immediately before an eraser is a select-then-delete, whereas the same eraser alone is a drag. Testing that ordering hypothesis is cheaper than continuing to search fields and should come first.

## Verification

`149/149` tests pass (including two new ones), `tsc --noEmit` clean, `eslint` clean.
