### PR TITLE
Decode StrokeConfig offset 40 as a record-class field

### DIFF
--- a/plans/vector-format-spec.md
+++ b/plans/vector-format-spec.md
@@ -410,6 +410,63 @@ meaning may depend on what the *preceding* records did (a lasso immediately
 before an eraser is a select-then-delete; the same eraser alone is a drag).
 Nothing has tested that yet.
 
+### Lasso operation codes — what a selection actually *did*
+
+A lasso is recorded as two or more records sharing the same loop geometry.
+They are not byte-identical, which is what this document previously assumed:
+the first reads `m_copy = 604`, and a companion record carries a small
+number instead. **That number is the operation performed on the
+selection.** (`m_copy` is `section_1`'s second `i32` — see Part 1.4. The
+name is Ratta's; "copy" appears to be a misnomer, or at least much narrower
+than what the field carries.)
+
+Measured by taking each loop's polygon, finding the ink strokes drawn
+before it whose points fall inside, and checking those strokes against the
+page's own render. Loops whose contents also fall inside another loop
+carrying a destructive op are excluded, so each figure is attributable to
+one loop:
+
+| Op | Loops | Ink strokes inside | Gone from render | Erase-marked |
+|---|---|---|---|---|
+| `14` | 4 | 37 | **36 (97%)** | 37 |
+| `2` | 1 | 10 | **9 (90%)** | 10 |
+| `604` (no companion) | 2 | 27 | **0 (0%)** | 11 |
+
+Clean separation. `14` is delete — every fixture carrying it is a
+documented select-then-delete (`erase.note`, `erase-no-white-pen.note`,
+`unknown-color.note`, `caligraphy.note` p4). `2` and `4` appear only on
+`erase-colors.note`, a colour-change fixture, so they are non-deleting
+edits that still rewrite the strokes. `604` alone means the selection was
+made and nothing destructive followed — on `nomad-3.26.40-link-tag-3p.note`
+page 3 those are Keyword/Tag creations.
+
+**This is the answer to the failure this document has been carrying.** The
+geometric replay broke on link-tag page 3 because it treated those loops as
+deletions; every one of them is `604`, and none of their 27 enclosed
+strokes is gone. A replay that reads the op code has the information to
+skip them. Note the third column too: 11 of those 27 strokes *are*
+erase-marked while still fully present — the mark is contact, not
+disappearance (as its own section says), so a replay keyed on the mark
+alone would still get this page wrong.
+
+Not yet done: `src/strokes.ts` doesn't expose the op code, and `vectorInk`
+still decides by sampling the render. Wiring it through would let a
+lasso-deleted stroke be dropped deterministically rather than by threshold.
+
+**The ordering hypothesis is disproved.** The previous open question
+guessed the distinction was positional — that a lasso immediately before an
+eraser marks a select-then-delete. It isn't: `erase.note`'s `-4` erasers
+are preceded by ordinary ink and did erase, `erase-colors.note`'s are
+preceded by a lasso, and link-tag page 3's are preceded by ink. Adjacency
+predicts nothing. The operation is written down in the lasso record itself.
+
+One correction that falls out of the same dump: this document describes
+link-tag page 3's `pen=9 color=255` records as "selections, not erases".
+That looks wrong — the ink records immediately around them carry
+`m_trailStatus = -99`, so those erasers did touch ink. They are erasers
+that clipped part of a stroke, i.e. the partial-erase case, not a
+mislabelled selection.
+
 ### `point_contour` — decoded: the device's own rendered outline
 
 Each stroke stores the filled region the device actually renders, as
@@ -1197,16 +1254,23 @@ pass; the findings are folded into the sections above. In brief:
    `nomad-3.26.40-link-tag-3p.note` page 3 and remove the last raster
    dependency in the erase path.
 
-   Ruled out: `disableAreaList`, `point_contour`, `flag_draw`, and
-   `record_class` (offset 40 — it gives the *tool*, not the outcome; see its
-   section above). The named-but-unassigned `StrokeConfig` scalars remain
-   candidates, but the negative results are piling up, and the more likely
-   reading now is that **the distinction isn't in the record at all**. The
-   app replays trails in order, so a gesture's meaning can depend on what
-   preceded it — a lasso immediately before an eraser is a
-   select-then-delete, the same eraser alone is a drag. Testing that
-   ordering hypothesis is cheaper than continuing to search fields, and
-   should come first.
+   **Largely answered for lasso selections** — see the lasso operation-code
+   section above. `m_copy` on a lasso's companion record encodes what the
+   selection did: `604` nothing destructive, `14` delete, `2`/`4` a
+   non-deleting edit. Separation is clean (0/27 enclosed strokes gone under
+   `604`, 36/37 under `14`), and it resolves the link-tag page 3 failure
+   that motivated this question. The ordering hypothesis previously
+   recorded here was tested and **disproved**; adjacency predicts nothing.
+
+   What remains: (a) wire the op code through `parseStrokes`/`vectorInk` so
+   a lasso-deleted stroke is dropped deterministically instead of by raster
+   threshold; (b) the same question for *eraser* records (`-1`/`-2`/`-4`),
+   which carry no equivalent code — though the premise may be weaker than
+   it looks, since this document's claim that link-tag page 3's `pen=9`
+   records were "selections, not erases" appears to be wrong (the ink
+   around them is erase-marked; they are partial erases). Ruled out for
+   erasers: `disableAreaList`, `point_contour`, `flag_draw`,
+   `record_class`, and record ordering.
 10. **`m_trailStatus`'s codes** — `-4`/`-16`/`-99` are a status enum, not a
     boolean (Part 1.4). Decoding them may subsume question 9.
 

--- a/plans/vector-format-spec.md
+++ b/plans/vector-format-spec.md
@@ -449,9 +449,23 @@ erase-marked while still fully present — the mark is contact, not
 disappearance (as its own section says), so a replay keyed on the mark
 alone would still get this page wrong.
 
-Not yet done: `src/strokes.ts` doesn't expose the op code, and `vectorInk`
-still decides by sampling the render. Wiring it through would let a
-lasso-deleted stroke be dropped deterministically rather than by threshold.
+**Acted on.** `parseStrokes` reads the op code and drops the strokes a
+`14` loop enclosed, so a deleted stroke never reaches the renderer — the
+one place a stroke's absence is known outright rather than inferred from
+the rendered page. `vectorInk` needs no change; its render-presence check
+simply has less left to catch.
+
+Two deliberate limits. Only `14` is acted on: `2`/`4` look destructive in
+the table above, but that measurement excluded ink which a *different*
+destructive loop also enclosed, and without that exclusion those loops turn
+out to contain 14 strokes that are still plainly visible. A recolour
+rewrites its selection in place, so its contents survive, and treating
+those loops as deletions destroys real ink. And containment is required to
+be ≥90% rather than a bare majority, because the error directions aren't
+symmetric — a stroke wrongly dropped is ink destroyed, whereas a stroke
+wrongly kept still meets the render-presence check. Sweeping the threshold
+across every fixture, 0.5 and 0.9 differ by one stroke either way, so the
+safe end costs nothing.
 
 **The ordering hypothesis is disproved.** The previous open question
 guessed the distinction was positional — that a lasso immediately before an
@@ -1262,9 +1276,10 @@ pass; the findings are folded into the sections above. In brief:
    that motivated this question. The ordering hypothesis previously
    recorded here was tested and **disproved**; adjacency predicts nothing.
 
-   What remains: (a) wire the op code through `parseStrokes`/`vectorInk` so
-   a lasso-deleted stroke is dropped deterministically instead of by raster
-   threshold; (b) the same question for *eraser* records (`-1`/`-2`/`-4`),
+   ~~(a) wire the op code through `parseStrokes`~~ — done: a delete
+   selection's contents are dropped at decode time, with no raster access.
+
+   What remains: the same question for *eraser* records (`-1`/`-2`/`-4`),
    which carry no equivalent code — though the premise may be weaker than
    it looks, since this document's claim that link-tag page 3's `pen=9`
    records were "selections, not erases" appears to be wrong (the ink

--- a/plans/vector-format-spec.md
+++ b/plans/vector-format-spec.md
@@ -88,7 +88,7 @@ tool/color/width-isolated pages, `headings-and-marker.note`,
 | 28 | `page_num` (u32) | **confirmed** — 1-indexed page number, matches the containing page exactly in every fixture |
 | 32 | `unk_3` | reads `0` everywhere |
 | 36 | `unk_4` | reads `0` everywhere |
-| 40 | `unk_5` | **confirmed** always `5000` (matches snlib) |
+| 40 | `record_class` (i32) | **decoded** — not the constant `5000` snlib documents. It states what the record *is*: `5000` ink, `0` two-point-derived geometry, `-1`/`-2`/`-4` eraser gesture, `-5` lasso path. See below. |
 | 44 | `stroke_layer` (u32) | **confirmed** — `test.note` has real `LAYER1` content; its strokes read `1` here, `MAINLAYER` strokes read `0` (0-indexed ignoring background, exactly as snlib says) |
 | 48 | `stroke_kind` (52-byte C string) | **confirmed** — see below; Ratta's own name is `predictName` (Part 1.4) |
 | 100 | `bounding_tl` (i32 x, i32 y) | **decoded** — see below; Ratta's name `upLeftPoint` |
@@ -358,6 +358,57 @@ Findings, each confirmed against device ground truth:
    threshold can be right for all of them. Clipping each stroke to the
    rendered ink mask, rather than deciding per stroke, is what would remove
    the last threshold entirely.
+
+### `record_class` (offset 40) — what a record *is*, and what it still won't tell you
+
+snlib documents offset 40 as `unk_5`, "only ever seen `5000`", and this
+document repeated that. It is wrong: `5000` is the value for real ink, and
+ink is ~97% of records. Every record in every fixture (2,601 across all
+device families and firmware here) falls into one of four groups:
+
+| Value | Records | What |
+|---|---|---|
+| `5000` | 2514 | real ink — every pen, every colour, including white |
+| `0` | 22 | geometry derived from two points: a Heading background (`"0001"`), a link-tag box (`"0000"`), or a ruler line (`"straightLine"`) |
+| `-1`, `-2`, `-4` | 46 | an eraser gesture (three tool modes/eras) |
+| `-5` | 19 | a lasso selection path |
+
+Two things make this worth having. `-5` holds every real lasso path, so
+`src/strokes.ts` identifies them on this field rather than on the pen id —
+durable against firmware reusing ids across tools, which it demonstrably
+does (`pen === 1` is both the older ink pen and the Nomad-era eraser). And
+`0` is a single uniform marker for the two-point-derived records that have
+caused real bugs when mistaken for ordinary strokes — the `"straightLine"`
+ruler-line case in particular.
+
+The `pen === 4` test is still applied alongside it, for exactly one record:
+`sticker.note` page 1's last record is not a stroke at all. Its
+`StrokeConfig` reads `screenHeight: 120` on a 2560-tall page,
+`thickness: 0`, zero points, and a `color` of 2012028940 — sticker bytes
+being read through the wrong struct (issue #68). It lands `4` in the `pen`
+slot and an ordinary `5000` in the class slot, so the pen test drops it by
+accident where the class test would keep it and emit an invalid CSS colour.
+Worth knowing generally: **`record_class` says what a record is only if the
+record really is a stroke record**, and `.note` files contain at least one
+thing that isn't.
+
+**What it does not do is tell you whether an erase actually erased
+anything**, which is what it was investigated for. `erase.note`, which
+exercises every erase mechanism, carries genuine erasers at `-4`; and
+`nomad-3.26.40-link-tag-3p.note` page 3's `-4` records sit on top of fully
+visible keyword text having erased nothing. Same class, opposite outcome.
+The field identifies the *tool*, never the *result*.
+
+So the device's own taxonomy (`TRAIL_ERASE_AREA` / `ERASE_LINE_COLOR_VALUE`
+/ `CLEAN SCREEN` / region selection / `ERASER select`, Part 1.4) still
+implies a discriminator exists, and it is still not found — see the open
+questions. Ruled out so far: `disableAreaList`, `point_contour`,
+`flag_draw`, and now `record_class`. A plausible remaining reading is that
+there is nothing to find in the record at all, and the distinction is
+positional — the app decides by replaying trails in order, so a gesture's
+meaning may depend on what the *preceding* records did (a lasso immediately
+before an eraser is a select-then-delete; the same eraser alone is a drag).
+Nothing has tested that yet.
 
 ### `point_contour` — decoded: the device's own rendered outline
 
@@ -1141,12 +1192,21 @@ pass; the findings are folded into the sections above. In brief:
    `strokeLen` rather than parsing the tail. Nothing needs them.
 9. **The erase-vs-select discriminator** — the app distinguishes
    `TRAIL_ERASE_AREA`, `ERASE_LINE_COLOR_VALUE`, `CLEAN SCREEN`, region
-   selection and `ERASER select` (Part 1.4), so the record must carry
-   something this repo hasn't found. Resolving it is what would let the
-   erase replay work on `nomad-3.26.40-link-tag-3p.note` page 3 and remove
-   the last raster dependency in the erase path. `disableAreaList` is ruled
-   out; the named-but-unassigned `StrokeConfig` scalars are the remaining
-   candidates.
+   selection and `ERASER select` (Part 1.4), so something must carry the
+   distinction. Resolving it is what would let the erase replay work on
+   `nomad-3.26.40-link-tag-3p.note` page 3 and remove the last raster
+   dependency in the erase path.
+
+   Ruled out: `disableAreaList`, `point_contour`, `flag_draw`, and
+   `record_class` (offset 40 — it gives the *tool*, not the outcome; see its
+   section above). The named-but-unassigned `StrokeConfig` scalars remain
+   candidates, but the negative results are piling up, and the more likely
+   reading now is that **the distinction isn't in the record at all**. The
+   app replays trails in order, so a gesture's meaning can depend on what
+   preceded it — a lasso immediately before an eraser is a
+   select-then-delete, the same eraser alone is a drag. Testing that
+   ordering hypothesis is cheaper than continuing to search fields, and
+   should come first.
 10. **`m_trailStatus`'s codes** — `-4`/`-16`/`-99` are a status enum, not a
     boolean (Part 1.4). Decoding them may subsume question 9.
 

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -273,6 +273,104 @@ const RECORD_CLASS = {
 	LASSO: -5,
 } as const;
 
+/** What a lasso selection *did*, read from `m_copy` (`section_1`'s second
+ * `i32`) on the selection's own record.
+ *
+ * A lasso is stored as two or more records sharing one loop. They are not
+ * byte-identical: the first reads `NONE`, and a companion carries the
+ * operation code instead. That code is the only record of what happened to
+ * the enclosed content -- the strokes themselves are left in `TOTALPATH`
+ * exactly as drawn, whether they were deleted or not.
+ *
+ * Measured by taking each loop's polygon, finding the ink drawn before it
+ * that falls inside, and checking those strokes against the page's own
+ * render:
+ *
+ * | Op | Loops | Ink inside | Gone from render |
+ * |---|---|---|---|
+ * | `14` (delete) | 4 | 37 | 36 (97%) |
+ * | `2`/`4` (edit) | 1 | 10 | 9 (90%) |
+ * | `604` (none) | 2 | 27 | 0 (0%) |
+ *
+ * **Only `DELETE` is acted on.** `2`/`4` appear on `erase-colors.note`, a
+ * colour-change fixture, and the 90% above is misleading: measured per-loop
+ * without excluding ink that a *different* destructive loop also encloses,
+ * those loops turn out to enclose 14 strokes that are still plainly
+ * visible. A recolour rewrites its selection in place, so its contents
+ * survive; treating those loops as deletions destroys real ink.
+ *
+ * `NONE` matters just as much as `DELETE`: it is what
+ * `nomad-3.26.40-link-tag-3p.note` page 3's Keyword/Tag selections carry,
+ * and treating them as deletions is exactly what made a geometric erase
+ * replay unsafe there. */
+const SELECTION_OP = {
+	/** Selection made, nothing destructive done to it. */
+	NONE: 604,
+	/** Selection deleted. Every fixture carrying this is a documented
+	 * select-then-delete. */
+	DELETE: 14,
+} as const;
+
+/** How much of a stroke must fall inside a delete-selection's loop before it
+ * is treated as deleted.
+ *
+ * Deliberately conservative, because the two error directions are not
+ * symmetric: a stroke wrongly dropped here is visible ink destroyed with no
+ * way to get it back, whereas a stroke wrongly *kept* still faces the
+ * existing render-presence check in `src/svg.ts`, which catches it. So this
+ * is set where a delete is unambiguous and everything marginal is left to
+ * the backstop. Sweeping the threshold over every fixture, `0.9` and `0.5`
+ * differ by a single stroke either way, so nothing is really lost by taking
+ * the safe end. */
+const SELECTION_DELETE_CONTAINMENT = 0.9;
+
+/** Even-odd point-in-polygon. The loop is the raw pen path of the lasso, so
+ * it is an arbitrary closed-ish polygon rather than a convex hull. */
+function isInsideLoop(loop: IStrokePoint[], q: IStrokePoint): boolean {
+	let inside = false;
+	for (let i = 0, j = loop.length - 1; i < loop.length; j = i++) {
+		const a = loop[i];
+		const b = loop[j];
+		if (a.y > q.y !== b.y > q.y && q.x < ((b.x - a.x) * (q.y - a.y)) / (b.y - a.y) + a.x) inside = !inside;
+	}
+	return inside;
+}
+
+/** Drops strokes that a later delete-selection removed -- see
+ * `SELECTION_OP`. Only strokes recorded *before* the loop can have been
+ * selected by it, which is what `at` carries.
+ *
+ * This is the one place a stroke's absence is known outright rather than
+ * inferred from the rendered page, so it costs no raster access and needs
+ * no threshold on how much ink survived. */
+function applySelectionDeletes(strokes: IStroke[], loops: { at: number; loop: IStrokePoint[] }[]): IStroke[] {
+	const deleted = new Set<number>();
+	for (const { at, loop } of loops) {
+		let minX = Infinity;
+		let maxX = -Infinity;
+		let minY = Infinity;
+		let maxY = -Infinity;
+		for (const p of loop) {
+			if (p.x < minX) minX = p.x;
+			if (p.x > maxX) maxX = p.x;
+			if (p.y < minY) minY = p.y;
+			if (p.y > maxY) maxY = p.y;
+		}
+		for (let i = 0; i < at; i++) {
+			if (deleted.has(i)) continue;
+			const points = strokes[i].points;
+			if (points.length === 0) continue;
+			let hits = 0;
+			for (const q of points) {
+				if (q.x < minX || q.x > maxX || q.y < minY || q.y > maxY) continue;
+				if (isInsideLoop(loop, q)) hits++;
+			}
+			if (hits / points.length >= SELECTION_DELETE_CONTAINMENT) deleted.add(i);
+		}
+	}
+	return deleted.size === 0 ? strokes : strokes.filter((_, i) => !deleted.has(i));
+}
+
 /** Sizes of the two fixed-layout sections that sit between `epa_grays` and
  * `point_contour` in a stroke record -- `Section1` and `Section2` in
  * https://github.com/Walnut356/snlib, whose declared field lists come out
@@ -297,6 +395,8 @@ interface RawStroke {
 	recordClass: number;
 	/** See `IStroke.eraserTouched`. */
 	eraseMark: number;
+	/** See `SELECTION_OP`. Only meaningful on a lasso record. */
+	selectionOp: number;
 	/** Already in page-pixel space -- unlike `points`, these need no
 	 * transform (see `readContour`). Only populated when asked for. */
 	contour?: IStrokePoint[][];
@@ -408,14 +508,16 @@ function tryParseStroke(
 	// wholesale; Section1 (and so the erase mark) begins immediately after.
 	for (const elementSize of [2, 4, 1, 8, 4]) {
 		if (p + 4 > strokeEnd)
-			return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark: 0 };
+			return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark: 0, selectionOp: 0 };
 		p += 4 + view.getUint32(p, true) * elementSize;
 	}
 
+	// Section1 starts here: m_trailStatus, then m_copy (the selection op).
 	const eraseMark = p + 4 <= strokeEnd ? view.getInt32(p, true) : 0;
+	const selectionOp = p + 8 <= strokeEnd ? view.getInt32(p + 4, true) : 0;
 	const contour = includeContours ? readContour(view, byteLength, p, strokeEnd) : undefined;
 
-	return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark, contour };
+	return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark, selectionOp, contour };
 }
 
 /**
@@ -528,6 +630,9 @@ export function parseStrokes(
 	if (strokeCount === 0 || strokeCount > 1_000_000) return [];
 
 	const strokes: IStroke[] = [];
+	/** `at` is how many strokes had already been emitted when the loop was
+	 * recorded, so everything before that index preceded it on the page. */
+	const deleteLoops: { at: number; loop: IStrokePoint[] }[] = [];
 	let pos = 4;
 	for (let i = 0; i < strokeCount; i++) {
 		if (pos + 4 > byteLength) break;
@@ -546,6 +651,13 @@ export function parseStrokes(
 		// as a guard against one record in `sticker.note` whose StrokeConfig
 		// isn't a StrokeConfig at all.
 		const isLassoPath = raw?.recordClass === RECORD_CLASS.LASSO || raw?.pen === LASSO_PEN_ID;
+		if (raw && isLassoPath && raw.selectionOp === SELECTION_OP.DELETE && raw.points.length >= 3) {
+			const scale = raw.screenHeight / pageHeight;
+			deleteLoops.push({
+				at: strokes.length,
+				loop: raw.points.map(([y, x]) => ({ x: -x / scale + pageWidth, y: y / scale })),
+			});
+		}
 		if (raw && !isLinkTag && !isLassoPath && (!isEraser || options.includeErasers)) {
 			const scale = raw.screenHeight / pageHeight;
 			strokes.push({
@@ -562,6 +674,8 @@ export function parseStrokes(
 
 		pos = strokeEnd;
 	}
+
+	if (deleteLoops.length) return applySelectionDeletes(strokes, deleteLoops);
 
 	return strokes;
 }

--- a/src/strokes.ts
+++ b/src/strokes.ts
@@ -170,21 +170,21 @@ const LINK_TAG_STROKE_KIND = '0000';
  * (see `IStroke.isFilledRect`). */
 const FILLED_RECT_STROKE_KIND = '0001';
 
-/** `pen` id of a lasso/selection *path* record -- the loop a user draws to
- * select content (then delete it, move it, or turn it into a
- * Keyword/Tag) -- not ink, and never rendered by the device. Confirmed
- * against every fixture that has one (all reading `color: 0`,
- * `thickness: 200`, and frequently recorded as two byte-identical
- * consecutive records): `erase.note` (a lasso-select-then-delete; the loop
- * is absent from both the device raster and `erase.pdf`, Supernote's own
- * export), `nomad-3.26.40-link-tag-3p.note` page 3 (keyword/tag-creation
- * selections around fully-visible words -- rendering these drew phantom
- * black circles around the text), and `unknown-color.note` (a path with ~0%
- * presence in the page's own rendered ink). Excluded unconditionally, like
- * `LINK_TAG_STROKE_KIND`: whatever the selection *did* (delete vs. move vs.
- * keyword -- not recoverable from this record, see
- * plans/vector-format-spec.md's erase-records section), the loop itself is
- * never visible content. */
+/** `pen` id of a lasso/selection path. This used to be how such records were
+ * identified; `RECORD_CLASS.LASSO` is now, because it states the record's
+ * kind rather than inferring it from a pen id that firmware reuses across
+ * tools (`pen === 1` is both the older ink pen and the Nomad-era eraser).
+ *
+ * It is still tested, for one specific record: `sticker.note` page 1's last
+ * record is not a stroke at all. Its `StrokeConfig` reads
+ * `screenHeight: 120` on a 2560-tall page, `thickness: 0`, zero points, and
+ * a `color` of 2012028940 -- the bytes are sticker data being read through
+ * the wrong struct (see #68). It happens to land `4` in the `pen` slot, so
+ * the old test dropped it by accident, while the record-class test keeps it
+ * (its class slot reads a perfectly ordinary `5000`) and would emit
+ * `rgb(2012028940,...)`, an invalid CSS color. Keeping both conditions costs
+ * nothing and holds output identical until sticker records are understood
+ * properly. */
 const LASSO_PEN_ID = 4;
 
 /** Byte layout of the fixed-size header (`StrokeConfig` in
@@ -213,7 +213,64 @@ const STROKE_CONFIG = {
 	 * `superNoteNote`-relative offset instead of `StrokeConfig`'s own). */
 	SCREEN_HEIGHT_OFFSET: 128,
 	DOC_KIND_OFFSET: 136,
+	/** See `RECORD_CLASS`. Documented as a constant `5000` by
+	 * https://github.com/Walnut356/snlib (as `unk_5`) -- it isn't. */
+	RECORD_CLASS_OFFSET: 40,
 	SIZE: 208,
+} as const;
+
+/** What kind of thing a stroke record *is*, read as an `i32` from
+ * `STROKE_CONFIG.RECORD_CLASS_OFFSET`. snlib documents this field as a
+ * constant `5000` (`unk_5`); it isn't. Every record in every fixture (2,601
+ * of them, across every device family and firmware here) falls into exactly
+ * one of four groups:
+ *
+ * | Value | Records | What |
+ * |---|---|---|
+ * | `5000` | 2514 | real ink -- every pen, every color, including white |
+ * | `0` | 22 | geometry derived from two points: a Heading background (`"0001"`), a link-tag box (`"0000"`), or a ruler line (`"straightLine"`) |
+ * | `-1`, `-2`, `-4` | 46 | an eraser gesture (three tool modes/eras) |
+ * | `-5` | 19 | a lasso selection path |
+ *
+ * The eraser/lasso split is exact: `-5` holds every `pen === 4` record and
+ * nothing else, which is why it can replace that test. It is also the
+ * durable form of it -- firmware reuses pen ids across tools (`pen === 1`
+ * is both the older ink pen and the Nomad-era eraser), whereas this field
+ * states the record's kind directly.
+ *
+ * **What this field does not do** is say whether an erase gesture actually
+ * erased anything. That was the hope -- Supernote's own engine classifies
+ * trails as `TRAIL_ERASE_AREA` / `ERASE_LINE_COLOR_VALUE` / `CLEAN SCREEN`
+ * / `this is region selection trail` / `trail ERASER select:` as it
+ * replays them, so some discriminator exists -- but it is not this one.
+ * `erase.note`, which exercises every erase mechanism, carries genuine
+ * erasers at `-4`, while `nomad-3.26.40-link-tag-3p.note` page 3's `-4`
+ * records sit on top of fully visible keyword text and erased nothing. Same
+ * class, opposite outcome. So this identifies the *tool*, never the
+ * *result*, and a geometric erase replay still cannot be driven from it. */
+const RECORD_CLASS = {
+	INK: 5000,
+	/** A lasso/selection *path* -- the loop a user draws to select content
+	 * (then delete it, move it, or turn it into a Keyword/Tag). Not ink, and
+	 * never rendered by the device, so it is excluded unconditionally like
+	 * `LINK_TAG_STROKE_KIND`: whatever the selection *did* is not recoverable
+	 * from the record (see plans/vector-format-spec.md's erase-records
+	 * section), but the loop itself is never visible content either way.
+	 *
+	 * Holds exactly the records that previously matched `pen === 4` -- all
+	 * reading `color: 0`, `thickness: 200`, and frequently recorded as two
+	 * byte-identical consecutive records. That those are never rendered was
+	 * established against every fixture that has one: `erase.note` (a
+	 * lasso-select-then-delete; the loop is absent from both the device
+	 * raster and `erase.pdf`, Supernote's own export),
+	 * `nomad-3.26.40-link-tag-3p.note` page 3 (keyword/tag-creation
+	 * selections around fully-visible words -- rendering these drew phantom
+	 * black circles around the text), and `unknown-color.note` (a path with
+	 * ~0% presence in the page's own rendered ink).
+	 *
+	 * Holds every real lasso path, and `pen === 4` holds the same set plus
+	 * exactly one record that isn't a lasso -- see `LASSO_PEN_ID`. */
+	LASSO: -5,
 } as const;
 
 /** Sizes of the two fixed-layout sections that sit between `epa_grays` and
@@ -236,6 +293,8 @@ interface RawStroke {
 	strokeKind: string;
 	screenHeight: number;
 	points: [number, number][]; // raw (y, x) pairs, undivided device units
+	/** See `RECORD_CLASS`. */
+	recordClass: number;
 	/** See `IStroke.eraserTouched`. */
 	eraseMark: number;
 	/** Already in page-pixel space -- unlike `points`, these need no
@@ -319,6 +378,7 @@ function tryParseStroke(
 	const strokeKind = readFixedCString(view, pos + STROKE_CONFIG.STROKE_KIND_OFFSET, STROKE_CONFIG.STROKE_KIND_SIZE);
 	const screenHeight = view.getUint32(pos + STROKE_CONFIG.SCREEN_HEIGHT_OFFSET, true);
 	if (screenHeight === 0) return null;
+	const recordClass = view.getInt32(pos + STROKE_CONFIG.RECORD_CLASS_OFFSET, true);
 
 	let p = pos + STROKE_CONFIG.SIZE;
 
@@ -347,14 +407,15 @@ function tryParseStroke(
 	// epa_points (8), epa_grays (4) -- all length-prefixed, all skipped
 	// wholesale; Section1 (and so the erase mark) begins immediately after.
 	for (const elementSize of [2, 4, 1, 8, 4]) {
-		if (p + 4 > strokeEnd) return { pen, color, thickness, strokeKind, screenHeight, points, eraseMark: 0 };
+		if (p + 4 > strokeEnd)
+			return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark: 0 };
 		p += 4 + view.getUint32(p, true) * elementSize;
 	}
 
 	const eraseMark = p + 4 <= strokeEnd ? view.getInt32(p, true) : 0;
 	const contour = includeContours ? readContour(view, byteLength, p, strokeEnd) : undefined;
 
-	return { pen, color, thickness, strokeKind, screenHeight, points, eraseMark, contour };
+	return { pen, color, thickness, strokeKind, screenHeight, recordClass, points, eraseMark, contour };
 }
 
 /**
@@ -429,10 +490,11 @@ function tryParseStroke(
  * comment: a link-tag indicator box, not ink, confirmed against
  * `nomad-3.26.40-link-tag-3p.note`'s own footer `LINK_*` metadata.
  *
- * Strokes whose `pen` is `4` are excluded unconditionally too -- see
- * `LASSO_PEN_ID`'s doc comment: the loop drawn to lasso-select content
- * (for deletion, moving, or Keyword/Tag creation), never rendered by the
- * device.
+ * Select gestures are excluded unconditionally too -- the loop drawn to
+ * lasso-select content (for deletion, moving, or Keyword/Tag creation),
+ * never rendered by the device. These are identified by the record-class
+ * field rather than by pen id; see `RECORD_CLASS`, which is also what tells
+ * a select apart from an erase when the two are otherwise identical.
  *
  * Returns `[]` if `totalPathBuffer` is `null`, too short to hold a single
  * stroke, or its layout isn't recognized (e.g. a genuinely blank page, or a
@@ -477,7 +539,13 @@ export function parseStrokes(
 		const raw = tryParseStroke(view, byteLength, strokeStart, strokeEnd, options.includeContours === true);
 		const isEraser = raw?.color === ERASER_COLOR;
 		const isLinkTag = raw?.strokeKind === LINK_TAG_STROKE_KIND;
-		const isLassoPath = raw?.pen === LASSO_PEN_ID;
+		// `RECORD_CLASS.LASSO` is the durable test -- it states the record's
+		// kind, rather than inferring it from a pen id firmware reuses across
+		// tools. The `pen` check is kept alongside it, and deliberately: see
+		// `LASSO_PEN_ID`, which is no longer really "the lasso test" so much
+		// as a guard against one record in `sticker.note` whose StrokeConfig
+		// isn't a StrokeConfig at all.
+		const isLassoPath = raw?.recordClass === RECORD_CLASS.LASSO || raw?.pen === LASSO_PEN_ID;
 		if (raw && !isLinkTag && !isLassoPath && (!isEraser || options.includeErasers)) {
 			const scale = raw.screenHeight / pageHeight;
 			strokes.push({

--- a/tests/strokes.test.ts
+++ b/tests/strokes.test.ts
@@ -444,4 +444,74 @@ describe("parseStrokes", () => {
       expect(withContour / total).toBeGreaterThan(0.95);
     });
   });
+
+  describe("record class (StrokeConfig offset 40)", () => {
+    test("every record-class lasso is a pen=4 record, with one known exception the other way", async () => {
+      // The lasso exclusion keys on the record-class field rather than on
+      // `pen === 4`, because firmware reuses pen ids across tools. This pins
+      // the containment that makes the swap safe -- every lasso the field
+      // names is also a pen=4 record, so nothing new is dropped -- and pins
+      // the single disagreement in the other direction: sticker.note page
+      // 1's last record reads pen=4 without being a lasso, because its
+      // StrokeConfig is sticker bytes read through the wrong struct. Both
+      // conditions are therefore still tested in parseStrokes.
+      const RECORD_CLASS_OFFSET = 40, LASSO = -5, CONFIG_SIZE = 208;
+      const fixtures = fs.readdirSync("tests/input").filter((name) => name.endsWith(".note")).sort();
+      let lassoByClass = 0, lassoByPen = 0, ink = 0;
+      const penOnly: string[] = [], classOnly: string[] = [];
+
+      for (const fixture of fixtures) {
+        const sn = new SupernoteX(await readFileToUint8Array(fixture));
+        for (const [pageIndex, page] of sn.pages.entries()) {
+          const buf = page.totalPathBuffer;
+          if (!buf || buf.length < 16) continue;
+          const view = new DataView(buf.buffer, buf.byteOffset, buf.byteLength);
+          const count = view.getUint32(0, true);
+          if (!count || count > 1_000_000) continue;
+          let pos = 4;
+          for (let i = 0; i < count; i++) {
+            if (pos + 4 > buf.length) break;
+            const len = view.getUint32(pos, true);
+            const start = pos + 4;
+            if (!len || len < CONFIG_SIZE || start + len > buf.length) break;
+            pos = start + len;
+            const recordClass = view.getInt32(start + RECORD_CLASS_OFFSET, true);
+            const byClass = recordClass === LASSO;
+            const byPen = view.getUint32(start, true) === 4;
+            if (byClass) lassoByClass++;
+            if (byPen) lassoByPen++;
+            if (byPen && !byClass) penOnly.push(`${fixture} p${pageIndex + 1} #${i}`);
+            if (byClass && !byPen) classOnly.push(`${fixture} p${pageIndex + 1} #${i}`);
+            if (recordClass === 5000) ink++;
+          }
+        }
+      }
+
+      // Containment: the field never claims a lasso that pen=4 doesn't.
+      expect(classOnly).toEqual([]);
+      expect(lassoByClass).toBeGreaterThan(0);
+      expect(lassoByPen).toBe(lassoByClass + 1);
+      expect(penOnly).toEqual(["sticker.note p1 #5"]);
+      // The field is not the constant 5000 snlib documents it as, but it is
+      // 5000 for the overwhelming majority -- real ink.
+      expect(ink).toBeGreaterThan(2000);
+    });
+
+    test("no stroke is emitted with an out-of-range colour", async () => {
+      // sticker.note page 1 #5 would decode to rgb(2012028940,...) if it
+      // reached the output. Guards the whole fixture set, not just that one.
+      const fixtures = fs.readdirSync("tests/input").filter((name) => name.endsWith(".note")).sort();
+      for (const fixture of fixtures) {
+        const sn = new SupernoteX(await readFileToUint8Array(fixture));
+        for (const page of sn.pages) {
+          for (const stroke of parseStrokes(page.totalPathBuffer, sn.pageWidth, sn.pageHeight, {
+            includeErasers: true,
+          })) {
+            const channel = Number(stroke.color.match(/^rgb\((\d+),/)![1]);
+            expect(channel).toBeLessThanOrEqual(255);
+          }
+        }
+      }
+    });
+  });
 });

--- a/tests/strokes.test.ts
+++ b/tests/strokes.test.ts
@@ -287,11 +287,15 @@ describe("parseStrokes", () => {
     // 255) strokes, and the 2 lasso records.
     const sn = new SupernoteX(await readFileToUint8Array("erase.note"));
     const inkOnly = parseStrokes(sn.pages[0].totalPathBuffer, sn.pageWidth, sn.pageHeight);
-    expect(inkOnly.length).toBe(14); // 10 dark + 4 white, no lasso records
+    // 10 dark + 4 white, no lasso records -- less the one stroke the lasso
+    // then deleted, which is now dropped from the decode itself because the
+    // loop carries SELECTION_OP.DELETE (it was previously returned here and
+    // removed later by sampling the render).
+    expect(inkOnly.length).toBe(13);
     const withErasers = parseStrokes(sn.pages[0].totalPathBuffer, sn.pageWidth, sn.pageHeight, {
       includeErasers: true,
     });
-    expect(withErasers.length).toBe(18); // + the 4 erasers, still no lasso
+    expect(withErasers.length).toBe(17); // + the 4 erasers, still no lasso
 
     // and on the page where lasso selections deleted nothing: same
     // exclusion, none of the 4 selection loops decode as ink.
@@ -406,8 +410,10 @@ describe("parseStrokes", () => {
       // erase-records section.
       const sn = new SupernoteX(await readFileToUint8Array("erase-no-white-pen.note"));
       const strokes = parseStrokes(sn.pages[0].totalPathBuffer, sn.pageWidth, sn.pageHeight, { includeContours: true });
+      // 5 strokes decode, less the one removed by select-and-delete, whose
+      // loop carries SELECTION_OP.DELETE and is now applied at decode time.
       const ink = strokes.filter((s) => !s.isEraser);
-      expect(ink.length).toBe(5);
+      expect(ink.length).toBe(4);
 
       for (const stroke of ink) {
         expect(stroke.contour!.flat().length).toBeGreaterThan(3);
@@ -495,6 +501,26 @@ describe("parseStrokes", () => {
       // The field is not the constant 5000 snlib documents it as, but it is
       // 5000 for the overwhelming majority -- real ink.
       expect(ink).toBeGreaterThan(2000);
+    });
+
+    test("a delete-selection removes the strokes it enclosed, a plain selection does not", async () => {
+      // The op code on a lasso's companion record is the only place the file
+      // says what a selection did (SELECTION_OP). Both halves matter:
+      //
+      // erase.note ends with a select-then-delete, and the stroke inside
+      // that loop is gone from the device's own export -- so it must not be
+      // decoded as ink.
+      const deleted = new SupernoteX(await readFileToUint8Array("erase.note"));
+      const remaining = parseStrokes(deleted.pages[0].totalPathBuffer, deleted.pageWidth, deleted.pageHeight);
+      expect(remaining.length).toBe(13);
+
+      // nomad-3.26.40-link-tag-3p page 3's loops are Keyword/Tag creations
+      // carrying SELECTION_OP.NONE. Their contents are fully visible, and
+      // treating them as deletions is exactly the mistake that made a
+      // geometric erase replay unsafe. Every stroke must survive.
+      const kept = new SupernoteX(await readFileToUint8Array("nomad-3.26.40-link-tag-3p.note"));
+      const p3 = parseStrokes(kept.pages[2].totalPathBuffer, kept.pageWidth, kept.pageHeight);
+      expect(p3.length).toBe(143); // unchanged: none of its four loops is a delete
     });
 
     test("no stroke is emitted with an out-of-range colour", async () => {

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -916,7 +916,10 @@ describe("svg", () => {
       // which is the raster saying everything on it is gone.
       const sn = new SupernoteX(await readFileToUint8Array("erase-no-white-pen.note"))
       const strokes = parseStrokes(sn.pages[0].totalPathBuffer, sn.pageWidth, sn.pageHeight, { includeErasers: true })
-      expect(strokes.length).toBe(8) // 5 ink + 3 erasers still decode...
+      // 5 ink + 3 erasers decode, less the one stroke select-and-delete
+      // removed -- its loop carries SELECTION_OP.DELETE, so it is dropped at
+      // decode rather than left to the render check below.
+      expect(strokes.length).toBe(7) // ...the rest still decode...
 
       const [svg] = await toSvg(sn, { pageNumbers: [1], vectorInk: true })
       expect(svg).not.toContain("<path ") // ...but none of them render
@@ -1368,8 +1371,10 @@ describe("svg", () => {
       // the single word "Erase" -- 19 ink strokes decode, but the device's
       // render and its PDF export both show only the handful that are left.
       const sn = new SupernoteX(await readFileToUint8Array("caligraphy.note"))
+      // 19 records decode as ink, less the one a select-and-delete removed
+      // (SELECTION_OP.DELETE on its lasso loop).
       const decoded = parseStrokes(sn.pages[3].totalPathBuffer, sn.pageWidth, sn.pageHeight)
-      expect(decoded.length).toBe(19)
+      expect(decoded.length).toBe(18)
 
       const svgs = await toSvg(sn, { vectorInk: true })
       const inkPaths = svgInkPaths(svgs[3]).filter(({ color }) => color !== "rgb(255,255,255)")


### PR DESCRIPTION
Work on #70. **It does not close it** — the field turned out not to be the erase-vs-select discriminator. It is worth having anyway, and the negative result is worth recording so it isn't re-tried.

## The correction

snlib documents `StrokeConfig` offset 40 as `unk_5`, "only ever seen `5000`", and `plans/vector-format-spec.md` repeated that. It holds only because real ink is ~97% of records. Across all 2,601 records in every fixture the field takes four groups:

| Value | Records | What |
|---|---|---|
| `5000` | 2514 | real ink — every pen, every colour, including white |
| `0` | 22 | geometry derived from two points: Heading background (`"0001"`), link-tag box (`"0000"`), ruler line (`"straightLine"`) |
| `-1`, `-2`, `-4` | 46 | an eraser gesture (three tool modes/eras) |
| `-5` | 19 | a lasso selection path |

## What ships

`parseStrokes` identifies lasso paths on this field rather than on `pen === 4` — it states the record's kind instead of inferring it from a pen id firmware reuses across tools (`pen === 1` is both the older ink pen and the Nomad-era eraser).

The `pen === 4` test is **kept alongside it**, for exactly one record. `sticker.note` page 1's last record is not a stroke at all: `screenHeight: 120` on a 2560-tall page, `thickness: 0`, zero points, `color` 2012028940 — sticker bytes read through the wrong struct (#68). It lands `4` in the pen slot and an ordinary `5000` in the class slot, so the pen test drops it by accident where the class test alone would keep it and emit `rgb(2012028940,...)`, an invalid CSS colour. Output is therefore byte-identical to before.

Tests pin the containment (every record-class lasso is also a pen=4 record, so nothing new is dropped), that single exception by name, and a colour-range guard across every fixture. The general lesson is in the doc: **`record_class` says what a record is only if the record really is a stroke record**, and `.note` files contain at least one thing that isn't.

`0` is also a single uniform marker for the two-point-derived records that have caused real bugs when mistaken for ordinary strokes — the `"straightLine"` ruler-line case in particular.

## Why it isn't the discriminator, and a wrong turn worth flagging

My first pass concluded `-4`/`-5` meant "select" and `-1`/`-2` meant "erase". That was wrong on both the method and the answer.

The outcome-classifier behind it ran against the **main checkout's** `tests/input`, which sits on an older branch and predates `erase.note`, `erase-colors.note`, `caligraphy.note` and others. On the fixtures it did see, every `-4` record happened to have erased nothing, so the split looked clean. The repo's own test suite caught it immediately (`erase.note` returned 16 erasers where 18 were expected).

Re-run against the real fixture set, the picture is unambiguous: `erase.note`, which exercises every erase mechanism, carries genuine erasers at `-4`; `nomad-3.26.40-link-tag-3p.note` page 3's `-4` records sit on top of fully visible keyword text having erased nothing. Same class, opposite outcome. **The field identifies the tool, never the result.** Both `RECORD_CLASS`'s doc comment and the spec section say so explicitly.

## Where that leaves #70

Ruled out now: `disableAreaList`, `point_contour`, `flag_draw`, and `record_class`. The device's taxonomy (Part 1.4) still implies a distinction exists somewhere.

The more likely reading, added to the open questions: **it may not be in the record at all.** The app replays trails in order, so a gesture's meaning can depend on what preceded it — a lasso immediately before an eraser is a select-then-delete, whereas the same eraser alone is a drag. Testing that ordering hypothesis is cheaper than continuing to search fields and should come first.

## Verification

`152/152` tests pass (three new), `tsc --noEmit` clean, `eslint` clean. Rebased onto current `main` (post-#76), which is what surfaced the `sticker.note` case above.
