### PR TITLE
Let a marker cover ink lighter than itself, instead of always sliding under

### DIFF
--- a/plans/vector-format-spec.md
+++ b/plans/vector-format-spec.md
@@ -735,6 +735,50 @@ everywhere else.
 The raster resampling is now avoidable: the displayed text color is the
 last three digits of the heading's `TITLESTYLE` value (below).
 
+### Draw order — record order, except where the marker tool goes underneath
+
+`TOTALPATH` records are in the order the device replays them, and that is
+also the order it paints them in: later ink covers earlier ink. Two
+exceptions are the whole of what a renderer has to know beyond "draw them in
+order".
+
+**A Heading's rect record sits after the ink it backs.** The 2-point
+background record for a Heading is written *after* the label strokes drawn
+inside it, so painting it in place hides them. Rects are drawn first.
+
+**The marker tool goes under ink that is darker than it.** A highlighter
+pass is recorded after the writing it crosses — in every fixture here, every
+marker record sits later in the buffer than every non-marker stroke it
+overlaps — yet the device still draws that writing on top. It is not the
+tool that decides this, it's the darkness:
+
+| Fixture | Marker | Crosses | Device draws |
+|---|---|---|---|
+| `nomad-3.15.27-blank-shapes-and-RTR.note` p1 | grey 202/158 | black pen text | text on top of the band |
+| `nomad-3.26.40-link-tag-3p.note` p1 | grey 202/158 | black pen lines | lines on top of the bands |
+| `sticker.note` p2 | black 1 | the sticker plugin's artwork | the marker line on top, hiding the sticker's white detail |
+| `nomad-3.26.40-link-tag-3p.note` p1 | white 254 | black pen lines | the white, wiping the lines out |
+| `headings-and-marker.note` p3 | white 254 | the black word "White" | the white, leaving only flecks of black |
+| `erase.note` p1, `erase-pen.note` p2 | white 254 | a black marker band | the white, cutting the band |
+
+Read together: **the darker of the two wins, and white always wins.** White
+is not a shade in this scheme — it is the palette's cover-up color, the same
+role it plays in an eraser record (`ERASER_COLOR`, above).
+
+Both directions were checked against the device's own PDF export *and* the
+page's own raster, which agree. The exports are composited, not a stroke
+list: a page's ink comes out merged into one path per color, with each
+color's geometry already clipped to what is actually visible — which is how
+the sticker page shows it, its white detail arriving as fragments where the
+marker line crossed it.
+
+`src/svg.ts` reproduces this by ordering rather than by blending
+(`isHighlighterPass`): a marker lighter than ink it overlaps is drawn
+beneath the page's other ink, and any other marker is drawn in its own
+record order. Ordering can express every case in the corpus; it would fall
+short only for a single marker stroke that crosses both darker and lighter
+ink at once, which no fixture here does.
+
 ## Part 1.4 — Field names from Ratta's own binary
 
 The Supernote Partner app for Windows ships Ratta's notebook engine as

--- a/scripts/build-fixture-site.ts
+++ b/scripts/build-fixture-site.ts
@@ -77,7 +77,7 @@ const FIXTURE_NOTES: Record<string, { isolates: string; note?: string }> = {
 	},
 	sticker: {
 		isolates: 'The sticker plugin — artwork placed as ordinary stroke records, in a shape the centreline model cannot express.',
-		note: 'The one page whose ratio is wrong about it. Page 2\'s sticker is filled the way a person fills a shape with a pen, black strokes doubling back over themselves with white carved back over the top, so our 22 overlapping outlines get summed where the device\'s export merges its black into a single path counted once. Rasterised instead of summed, the ink we lay down covers 42,704 square pixels against the device\'s 42,800 — the picture agrees even where the number says 1.36×.',
+		note: 'The one page whose ratio is wrong about it. Page 2\'s sticker is filled the way a person fills a shape with a pen, black strokes doubling back over themselves with white carved back over the top, so our 22 overlapping outlines get summed where the device\'s export merges its black into a single path counted once. Rasterised instead of summed, the ink we lay down covers 42,704 square pixels against the device\'s 42,800 — the picture agrees even where the number says 1.36×. The black marker line across it is also what settled draw order: sorting every marker under the pen ink drew the sticker over the line, where the device draws the line over the sticker.',
 	},
 	turkish: {
 		isolates: 'Dense handwriting with erasures throughout, then rewritten in place.',

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -117,8 +117,9 @@ function buildRecognitionTextElements(page: IPdfPage, pageWidth: number): string
  * hides it entirely).
  *
  * `'path'`'s `tier` is `'marker'` exactly when the stroke's own real `pen`
- * field says `'marker'` -- see `buildStrokePathElements` for what `tier`
- * actually changes. */
+ * field says `'marker'` -- it records the *tool*, not a fixed layer. Whether
+ * a given marker stroke ends up beneath the page's other ink is decided per
+ * stroke from what it actually crosses; see `isHighlighterPass`. */
 export type StrokeStyle =
 	| { shape: 'path'; color: string; width: number; tier: 'marker' | 'pen' }
 	| { shape: 'rect'; color: string; fill: 'solid' | 'hatch' }
@@ -202,30 +203,138 @@ function buildPathElement(stroke: IStroke, style: { color: string; width: number
 	return `<path d="${d}" fill="none" stroke="${style.color}" stroke-width="${style.width}" stroke-linecap="round" stroke-linejoin="round"/>`;
 }
 
-/** Builds every stroke's SVG element in three fixed tiers -- `'rect'`s,
- * then wide ("marker") `'path'`s, then narrow ("pen") `'path'`s -- instead
- * of strictly in `strokes`' order (i.e. TOTALPATH buffer order, which
- * doesn't reliably match how layered content was actually drawn). Confirmed
- * on real fixtures both ways: a Heading's `'rect'` background record sits
- * *after* the digit stroke it's meant to sit behind, and a highlighter
- * pass's record can sit after the pen ink drawn over it too -- either way,
- * drawing in plain buffer order (SVG paints later elements on top) paints
- * the background/highlight over the ink and hides it. Sorting into these
- * tiers sidesteps needing to know the real chronological order at all: a
- * background fill or a wide highlighter mark is safe to draw before
- * narrower ink regardless of when it was actually drawn, since nothing
- * legitimately needs a highlighter mark drawn *over* the pen ink it's
- * highlighting. Relative order *within* each tier still follows
- * `strokes`. A stroke with no entry in `styles` (out-of-range index) is
- * skipped entirely, rather than falling back to a guessed color/width --
- * every stroke `parseStrokes` returns carries its own real style, so a
- * missing entry only happens from a caller-side index mismatch, not
- * anything `deriveStrokeStyle` itself produces. */
+/** Grey level of a `rgb(g,g,g)` ink color -- every color `parseStrokes`
+ * produces is a grey, so the red channel alone orders them from black (0) to
+ * white (254). */
+function greyLevel(color: string): number {
+	return Number(/rgb\((\d+)/.exec(color)?.[1] ?? '0');
+}
+
+/** How far apart two grey levels must sit to count as different shades.
+ * The device's own palette entries are far apart (0, 157, 201, 254) while
+ * the same shade is recorded a level apart in places (0 vs 1, 157 vs 158,
+ * 201 vs 202 -- see plans/vector-format-spec.md), so anything in between
+ * separates "the same shade" from "a genuinely lighter one" without needing
+ * the palette itself. */
+const SAME_GREY_TOLERANCE = 16;
+
+/** At or above this grey level, ink is the palette's white -- the color
+ * used to paint *over* something rather than to shade it (see
+ * `isHighlighterPass`). */
+const WHITE_INK_MIN_GREY = 250;
+
+interface StrokeBounds {
+	minX: number;
+	maxX: number;
+	minY: number;
+	maxY: number;
+}
+
+/** A stroke's own extent, from its sampled centerline or -- for a record
+ * that has none, like the sticker plugin's silhouette -- its rendered
+ * outline. `null` when the record carries no geometry at all. */
+function strokeBounds(stroke: IStroke): StrokeBounds | null {
+	const points = stroke.points.length ? stroke.points : (stroke.contour ?? []).flat();
+	if (points.length === 0) return null;
+	let minX = Infinity;
+	let maxX = -Infinity;
+	let minY = Infinity;
+	let maxY = -Infinity;
+	for (const point of points) {
+		if (point.x < minX) minX = point.x;
+		if (point.x > maxX) maxX = point.x;
+		if (point.y < minY) minY = point.y;
+		if (point.y > maxY) maxY = point.y;
+	}
+	return { minX, maxX, minY, maxY };
+}
+
+function boundsOverlap(a: StrokeBounds, b: StrokeBounds): boolean {
+	return a.minX <= b.maxX && b.minX <= a.maxX && a.minY <= b.maxY && b.minY <= a.maxY;
+}
+
+/**
+ * Whether the marker-tool stroke at `index` is a *highlighter pass* -- a
+ * wash the device paints beneath the ink already on the page -- rather than
+ * a mark that covers what it crosses.
+ *
+ * The device settles this by darkness, not by tool: where a marker stroke
+ * meets ink that is already darker than it, the darker ink stays on top.
+ * Confirmed on the device's own renders of three fixtures, in both
+ * directions:
+ *
+ * - `nomad-3.15.27-blank-shapes-and-RTR.note` page 1's "TEXT HIGHLIGHT"
+ *   bands and `nomad-3.26.40-link-tag-3p.note` page 1's grey marker rows --
+ *   grey marker records written *after* the black pen strokes they cross,
+ *   which the device still draws with the black ink fully legible on top.
+ * - `sticker.note` page 2 -- a *black* marker line drawn across the sticker
+ *   plugin's artwork, which the device draws over the top, hiding the
+ *   sticker's own white detail strokes where the line crosses them (see
+ *   https://github.com/philips/supernote-typescript/issues/82). Sorting
+ *   every marker beneath every pen stroke is what got this backwards, and
+ *   is why this is decided per stroke.
+ *
+ * White is the exception the darkness rule can't express: a white marker is
+ * never a highlight, it's a cover-up, and the device draws it over whatever
+ * it crosses -- `erase.note` page 1 and `erase-pen.note` page 2 (white
+ * marker over a black marker band) and `nomad-3.26.40-link-tag-3p.note`
+ * page 1's white marker row (over black pen lines), all of which the device
+ * renders as the white winning.
+ *
+ * Only ink recorded *before* this stroke is considered: anything recorded
+ * after it already paints over it in record order, which is what the device
+ * does too.
+ */
+function isHighlighterPass(index: number, boundsList: (StrokeBounds | null)[], greys: number[], drawable: boolean[]): boolean {
+	const bounds = boundsList[index];
+	if (!bounds) return false;
+	const grey = greys[index];
+	if (grey >= WHITE_INK_MIN_GREY) return false;
+	for (let i = 0; i < index; i++) {
+		const other = boundsList[i];
+		if (!other || !drawable[i]) continue;
+		if (greys[i] + SAME_GREY_TOLERANCE >= grey) continue;
+		if (boundsOverlap(bounds, other)) return true;
+	}
+	return false;
+}
+
+/** Builds every stroke's SVG element in `strokes`' own order (i.e. TOTALPATH
+ * buffer order, which is the order the device itself replays them in), with
+ * two exceptions, each for a record whose buffer position doesn't match
+ * where its ink belongs:
+ *
+ * - **`'rect'`s first.** A Heading's `'rect'` background record sits *after*
+ *   the digit stroke it's meant to sit behind, so drawing it in place
+ *   (SVG paints later elements on top) covers that ink entirely.
+ * - **A highlighter pass beneath the rest.** A marker stroke lighter than
+ *   ink it crosses is a wash under that ink even though its record comes
+ *   later -- see `isHighlighterPass`, which is also why this is decided per
+ *   marker stroke rather than by putting every marker in a tier of its own.
+ *
+ * Relative order within each of the three groups still follows `strokes`. A
+ * stroke with no entry in `styles` (out-of-range index) is skipped entirely,
+ * rather than falling back to a guessed color/width -- every stroke
+ * `parseStrokes` returns carries its own real style, so a missing entry only
+ * happens from a caller-side index mismatch, not anything
+ * `deriveStrokeStyle` itself produces. */
 function buildStrokePathElements(strokes: IStroke[], styles: StrokeStyle[] | undefined): { defs: string; elements: string } {
 	const rectElements: string[] = [];
-	const markerElements: string[] = [];
-	const penElements: string[] = [];
+	const highlighterElements: string[] = [];
+	const inkElements: string[] = [];
 	const hatchColors = new Set<string>();
+
+	// Precomputed once per page: isHighlighterPass compares each marker
+	// stroke against every ink stroke recorded before it. Only `'path'`s
+	// count as ink to slide under -- a `'rect'` is drawn ahead of everything
+	// either way (see this function's own doc comment), so no marker needs
+	// reordering on account of one.
+	const boundsList = strokes.map(strokeBounds);
+	const greys = strokes.map((_, i) => {
+		const style = styles?.[i];
+		return style && style.shape !== 'skip' ? greyLevel(style.color) : 0;
+	});
+	const drawable = strokes.map((_, i) => styles?.[i]?.shape === 'path');
 
 	strokes.forEach((stroke, i) => {
 		const style = styles?.[i];
@@ -242,12 +351,13 @@ function buildStrokePathElements(strokes: IStroke[], styles: StrokeStyle[] | und
 		// geometry there is -- see buildContourElement.
 		const element = buildPathElement(stroke, style);
 		if (element === null) return;
-		const bucket = style.tier === 'marker' ? markerElements : penElements;
+		const bucket =
+			style.tier === 'marker' && isHighlighterPass(i, boundsList, greys, drawable) ? highlighterElements : inkElements;
 		bucket.push(element);
 	});
 
 	const defs = [...hatchColors].map(buildHatchPatternDef).join('');
-	return { defs, elements: rectElements.join('') + markerElements.join('') + penElements.join('') };
+	return { defs, elements: rectElements.join('') + highlighterElements.join('') + inkElements.join('') };
 }
 
 export interface AddSvgPageOptions {
@@ -454,10 +564,11 @@ const INK_PRESENCE_SAMPLE_COUNT = 60;
  * erased ink; what it still catches is a stroke that is invisible without
  * having been erased at all. `erase.note`'s rows were covered over with
  * *white ink* rather than erased, and Supernote's own export of that page
- * draws only the white. Those have to be dropped rather than
- * drawn-then-covered, because `buildStrokePathElements` sorts strokes into
- * tiers instead of keeping `TOTALPATH` order, so a white marker cover-up
- * can end up painted *under* the pen stroke it was meant to hide.
+ * draws only the white. Dropping the hidden stroke is not the only way that
+ * page could come out right -- a cover-up is recorded after the ink it
+ * hides, so drawing both in record order covers it (see
+ * `buildStrokePathElements`) -- but it is the cheaper one, and it keeps ink
+ * no viewer will ever see out of the output.
  *
  * Kept hard against zero: for a stroke the file says is live, "not one
  * sampled point of it has any matching ink" is the only safe reason to
@@ -504,7 +615,7 @@ function strokeInkPresence(
 	pageHeight: number,
 ): number {
 	if (stroke.points.length === 0) return 1;
-	const targetGrey = Number(/rgb\((\d+)/.exec(displayColor)?.[1] ?? '0');
+	const targetGrey = greyLevel(displayColor);
 	const radius = Math.max(1, Math.round(stroke.thickness / (THICKNESS_TO_PIXEL_SCALE * 2))) + INK_PRESENCE_SEARCH_MARGIN_PX;
 	const step = Math.max(1, Math.floor(stroke.points.length / INK_PRESENCE_SAMPLE_COUNT));
 

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -1071,33 +1071,15 @@ describe("svg", () => {
       }
     })
 
-    test("marker strokes always draw before pen strokes, regardless of TOTALPATH order (issue #56 follow-up)", { timeout: 30000 }, async () => {
-      // This fixture's "TEXT HIGHLIGHT" gray highlight band is a real
-      // marker-tool stroke, with the narrower black "TEXT"/"HIGHLIGHT" pen
-      // strokes layered on top of it in the real note -- but not
-      // necessarily earlier in TOTALPATH's own buffer order. Drawing
-      // strictly in buffer order can paint the marker highlight over the
-      // narrower ink and hide it. Tier is decided by the stroke's own real
-      // `pen` field (see deriveStrokeStyle), not by comparing rendered
-      // widths -- a marker stroke isn't guaranteed to render wider than
-      // every non-marker one on a given fixture, so draw order is verified
-      // here by matching each real stroke's own coordinates against the
-      // rendered SVG, not by re-inferring tier from stroke-width.
-      const sn = new SupernoteX(await readFileToUint8Array("nomad-3.15.27-blank-shapes-and-RTR.note"))
-      const strokes = parseStrokes(sn.pages[0].totalPathBuffer, sn.pageWidth, sn.pageHeight)
-      const markerStrokes = strokes.filter((s) => s.pen === "marker")
-      const penStrokes = strokes.filter((s) => s.pen !== "marker")
-      expect(markerStrokes.length).toBeGreaterThan(0)
-      expect(penStrokes.length).toBeGreaterThan(0)
-
-      // Each stroke is drawn as its own rendered outline (see svgInkPaths),
-      // whose points are the outline's rather than the centreline's, so a
-      // stroke is located in the output by extent instead of by coordinate
-      // equality: an outline hugs its own stroke, standing off it by half
-      // the line's width, so the drawn path whose bounding box is closest
-      // to the stroke's own is that stroke's. Draw order is then that
-      // path's position in document order.
-      const [svg] = await toSvg(sn, { pageNumbers: [1], vectorInk: true })
+    // Each stroke is drawn as its own rendered outline (see svgInkPaths),
+    // whose points are the outline's rather than the centreline's, so a
+    // stroke is located in the output by extent instead of by coordinate
+    // equality: an outline hugs its own stroke, standing off it by half the
+    // line's width, so the drawn path whose bounding box is closest to the
+    // stroke's own is that stroke's. Draw order is then that path's position
+    // in document order -- which is what decides what covers what, since SVG
+    // paints later elements on top.
+    const drawOrderLookup = (svg: string) => {
       const boundsOf = (points: { x: number; y: number }[]) => ({
         minX: Math.min(...points.map((p) => p.x)),
         maxX: Math.max(...points.map((p) => p.x)),
@@ -1105,8 +1087,10 @@ describe("svg", () => {
         maxY: Math.max(...points.map((p) => p.y)),
       })
       const drawn = svgInkPaths(svg).map((path, index) => ({ index, ...boundsOf(path.rings.flat()) }))
-      const drawIndexOf = (stroke: (typeof strokes)[number]) => {
-        const want = boundsOf(stroke.points)
+      return (stroke: { points: { x: number; y: number }[]; contour?: { x: number; y: number }[][] }) => {
+        const points = stroke.points.length ? stroke.points : (stroke.contour ?? []).flat()
+        if (points.length === 0) return -1
+        const want = boundsOf(points)
         let best = -1
         let bestDistance = Infinity
         for (const path of drawn) {
@@ -1119,11 +1103,85 @@ describe("svg", () => {
         }
         return best
       }
-      const lastMarkerIndex = Math.max(...markerStrokes.map(drawIndexOf).filter((i) => i !== -1))
+    }
+
+    test("a marker lighter than the ink it crosses draws beneath it (issue #56 follow-up)", { timeout: 30000 }, async () => {
+      // This fixture's "TEXT HIGHLIGHT" gray highlight band is a real
+      // marker-tool stroke, with the narrower black "TEXT"/"HIGHLIGHT" pen
+      // strokes layered on top of it in the real note -- but *later* in
+      // TOTALPATH's own buffer order than that ink, so drawing strictly in
+      // buffer order paints the highlight over the writing and hides it.
+      // The device doesn't: its own render of this page has every black
+      // letter fully legible over the grey. Which marker strokes that
+      // applies to is decided per stroke, from whether the marker is
+      // lighter than ink it crosses (see isHighlighterPass) -- so this
+      // fixture's *black* markers, which fill patterns rather than
+      // highlight, are deliberately not part of the claim.
+      const sn = new SupernoteX(await readFileToUint8Array("nomad-3.15.27-blank-shapes-and-RTR.note"))
+      const strokes = parseStrokes(sn.pages[0].totalPathBuffer, sn.pageWidth, sn.pageHeight)
+      const greyLevel = (color: string) => Number(/rgb\((\d+)/.exec(color)![1])
+      const highlighters = strokes.filter((s) => s.pen === "marker" && greyLevel(s.color) > 100 && greyLevel(s.color) < 250)
+      const penStrokes = strokes.filter((s) => s.pen !== "marker")
+      expect(highlighters.length).toBeGreaterThan(0)
+      expect(penStrokes.length).toBeGreaterThan(0)
+      // the highlight bands really do come after the writing they cover
+      expect(strokes.indexOf(highlighters[0])).toBeGreaterThan(strokes.indexOf(penStrokes[0]))
+
+      const [svg] = await toSvg(sn, { pageNumbers: [1], vectorInk: true })
+      const drawIndexOf = drawOrderLookup(svg)
+      const lastHighlighterIndex = Math.max(...highlighters.map(drawIndexOf).filter((i) => i !== -1))
       const firstPenIndex = Math.min(...penStrokes.map(drawIndexOf).filter((i) => i !== -1))
-      expect(lastMarkerIndex).toBeGreaterThan(-1)
+      expect(lastHighlighterIndex).toBeGreaterThan(-1)
       expect(firstPenIndex).toBeGreaterThan(-1)
-      expect(lastMarkerIndex).toBeLessThan(firstPenIndex)
+      expect(lastHighlighterIndex).toBeLessThan(firstPenIndex)
+    })
+
+    test("a marker darker than the ink it crosses draws over it (sticker.note, issue #82)", { timeout: 30000 }, async () => {
+      // The other direction of the same rule, and the case that shows a
+      // marker can't just be sorted under every pen stroke: page 2's black
+      // marker line is drawn across the sticker plugin's artwork, and
+      // Supernote's own render of the page -- both its PDF export and the
+      // page's own raster -- puts the line over the top, hiding the
+      // sticker's white detail strokes where it crosses them.
+      const sn = new SupernoteX(await readFileToUint8Array("sticker.note"))
+      const strokes = parseStrokes(sn.pages[1].totalPathBuffer, sn.pageWidth, sn.pageHeight, { includeContours: true })
+      const marker = strokes.filter((s) => s.pen === "marker")
+      expect(marker.length).toBe(1)
+      // the sticker's own strokes come first, the line across it last
+      expect(strokes.indexOf(marker[0])).toBe(strokes.length - 1)
+      const stickerStrokes = strokes.filter((s) => s !== marker[0])
+
+      const [, svg] = await toSvg(sn, { vectorInk: true })
+      const drawIndexOf = drawOrderLookup(svg)
+      const markerIndex = drawIndexOf(marker[0])
+      const lastStickerIndex = Math.max(...stickerStrokes.map(drawIndexOf).filter((i) => i !== -1))
+      expect(markerIndex).toBeGreaterThan(-1)
+      expect(markerIndex).toBeGreaterThan(lastStickerIndex)
+    })
+
+    test("a white marker covers the ink it was dragged over, rather than sliding under it (headings-and-marker.note page 3)", { timeout: 30000 }, async () => {
+      // White is the one color the "darker ink wins" rule can't place: a
+      // white marker isn't a highlight, it's a cover-up. This page's
+      // bottom row is the word "White" written in black pen and then
+      // painted over with the white marker, and the device's own export
+      // draws only the few flecks of black the white missed. Drawing every
+      // marker under the pen ink instead left the whole word legible.
+      const sn = new SupernoteX(await readFileToUint8Array("headings-and-marker.note"))
+      const strokes = parseStrokes(sn.pages[2].totalPathBuffer, sn.pageWidth, sn.pageHeight)
+      const whiteMarkers = strokes.filter((s) => s.pen === "marker" && s.color === "rgb(254,254,254)")
+      expect(whiteMarkers.length).toBeGreaterThan(0)
+      // the ink they cover is written first, the white pass over it last
+      const covered = strokes.filter(
+        (s) => s.pen !== "marker" && s.color === "rgb(0,0,0)" && s.points.some((p) => p.y > 1000 && p.y < 1180),
+      )
+      expect(covered.length).toBeGreaterThan(0)
+
+      const [, , svg] = await toSvg(sn, { vectorInk: true })
+      const drawIndexOf = drawOrderLookup(svg)
+      const firstWhiteIndex = Math.min(...whiteMarkers.map(drawIndexOf).filter((i) => i !== -1))
+      const lastCoveredIndex = Math.max(...covered.map(drawIndexOf).filter((i) => i !== -1))
+      expect(firstWhiteIndex).toBeGreaterThan(-1)
+      expect(firstWhiteIndex).toBeGreaterThan(lastCoveredIndex)
     })
 
     test("scales stroke coordinates together with upscale", { timeout: 60000 }, async () => {


### PR DESCRIPTION
Fixes #82.

## The bug

`vectorInk` sorted every marker-tool stroke beneath every pen stroke, on the reasoning that nothing legitimately needs a highlighter drawn *over* the ink it highlights. `sticker.note` page 2 is the counter-example the issue points at: a black marker line drawn across the sticker plugin's artwork. The device draws the line over the top, hiding the sticker's own white detail strokes where it crosses them; we drew the sticker over the line.

## What the device actually does

Not "marker goes under ink" — **the darker of the two wins, and white always wins**, white being the palette's cover-up colour rather than a shade (the same role it plays in an eraser record). Checked in both directions against Supernote's own PDF exports *and* the pages' own rasters, which agree:

| Fixture | Marker | Crosses | Device draws |
|---|---|---|---|
| `nomad-3.15.27-blank-shapes-and-RTR` p1 | grey 202/158 | black pen text | text on top of the band |
| `nomad-3.26.40-link-tag-3p` p1 | grey 202/158 | black pen lines | lines on top of the bands |
| `sticker` p2 | black 1 | the sticker artwork | the marker line on top |
| `nomad-3.26.40-link-tag-3p` p1 | white 254 | black pen lines | the white, wiping them out |
| `headings-and-marker` p3 | white 254 | the black word "White" | the white, leaving flecks |
| `erase` p1, `erase-pen` p2 | white 254 | a black marker band | the white, cutting the band |

Worth recording: those PDF exports are composited, not a stroke list — one merged path per colour, each already clipped to what is visible — which is how the sticker page shows its white detail arriving as fragments.

## The change

The decision moves from the tool to the stroke (`isHighlighterPass`): a marker lighter than ink it overlaps is drawn beneath the page's other ink; every other marker draws in its own record order. Rects still go first, unchanged. Ordering covers every case in the corpus — it would fall short only for one marker stroke crossing both darker and lighter ink at once, which no fixture does.

## Verification

Rasterised every page against the device's own export and counted differing pixels, before vs after. Three pages move, none regress:

| Page | before | after |
|---|---|---|
| `sticker` p2 | 112 | 68 |
| `headings-and-marker` p3 | 343 | 17 |
| `nomad-3.26.40-link-tag-3p` p1 | 1181 | 1076 |

`headings-and-marker` p3 is the incidental win: the word "White", painted over with the white marker, used to render in full and now comes out as the same few flecks the device draws.

`npm test` passes (177). The old "marker strokes always draw before pen strokes" test asserted the rule the device contradicts; it is now three tests, one per direction (lighter under, darker over, white covers). Spec notes added under a new "Draw order" section in `plans/vector-format-spec.md`.
