### PR TITLE
Export prepareVectorInkPages/buildRenderNoteForVectorInk for the Worker path

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,44 @@ const pdfBytes = await ctx.pdfDoc.save();
 
 Note that only page rendering (`toImage`/`encodePng`) is parallelizable this way — PDF assembly, including the final `pdfDoc.save()`, is a single main-thread operation regardless of how many Workers rendered pages.
 
+#### Vector ink from the parallel/Worker path
+
+`toPdf({ vectorInk: true })` redraws each page's pen strokes as crisp vector paths instead of baking them into the raster image. To reach the same from the parallel/Worker path above, prepare the per-page vector ink on the main thread and hand the resulting strokes/styles through to `addPdfPage`:
+
+```ts
+import {
+  SupernoteX, extractPdfPageData, prepareVectorInkPages, buildRenderNoteForVectorInk, createPdfContext, addPdfPage,
+} from 'supernote-typescript';
+
+const note = new SupernoteX(buffer);
+const pageNumbers = note.pages.map((_, i) => i + 1);
+const vectorInkPages = prepareVectorInkPages(note, pageNumbers, 1); // upscale 1: native resolution
+
+// buildRenderNoteForVectorInk() gives a copy of `note` with the bitmap ink
+// layers stripped from every page whose ink was replaced by vectors, so
+// the worker rasterizes only the background (BGLAYER) for those pages.
+const renderNote = buildRenderNoteForVectorInk(note, vectorInkPages);
+
+// Each page still goes through extractPdfPageData (or extractPageRenderData)
+// for the structured-clone-safe worker slice, but pulled from renderNote so
+// the ink layers are already gone where vectors replaced them.
+const pngBuffers = await Promise.all(
+  pageNumbers.map((n) => renderInWorker(extractPdfPageData(renderNote, n))),
+);
+
+const ctx = await createPdfContext();
+for (let i = 0; i < pageNumbers.length; i++) {
+  const vip = vectorInkPages[i];
+  await addPdfPage(ctx, note.pages[i], pngBuffers[i], {
+    strokes: vip.useVectorInk ? vip.strokes : undefined,
+    strokeStyles: vip.useVectorInk ? vip.styles : undefined,
+  });
+}
+const pdfBytes = await ctx.pdfDoc.save();
+```
+
+`prepareVectorInkPages` decides, per page, whether the decoded strokes are trustworthy enough to replace the rasterized ink (it falls back to the raster for any page whose ink doesn't decode or decodes to nothing), so the only thing the caller does is pass the `strokes`/`strokeStyles` it produced through to `addPdfPage` for the pages where `useVectorInk` is true. Coordinates are in the same native page-pixel space as `toImage`'s raster at `upscale: 1`.
+
 ### Generating searchable SVGs
 
 `toSvg` renders each page to a standalone SVG document: the rasterized page image embedded as a base64 PNG, with the recognized handwriting (RTR) text overlaid invisibly at the position it was written, same as `toPdf`. SVG has no native multi-page container, so `toSvg` returns one SVG string per page.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,8 @@ export { toPdf, createPdfContext, addPdfPage, addTextOnlyPdfPage } from './pdf.j
 export type { ToPdfOptions, PdfContext, AddPdfPageOptions } from './pdf.js';
 export { toSvg, addSvgPage } from './svg.js';
 export type { ToSvgOptions, AddSvgPageOptions } from './svg.js';
-export type { StrokeStyle, VectorInkPrimitive } from './vector-ink.js';
+export type { StrokeStyle, VectorInkPrimitive, VectorInkPage } from './vector-ink.js';
+export { prepareVectorInkPages, buildRenderNoteForVectorInk } from './vector-ink.js';
 export { parseStrokes } from './strokes.js';
 export type { IStroke, IStrokePoint, StrokePen } from './strokes.js';
 export { SupernoteAtelier } from './atelier.js';


### PR DESCRIPTION
## Why

`toPdf({ vectorInk: true })` and `toSvg({ vectorInk: true })` are convenience wrappers, but the README's other documented integration — assembling a PDF from structured-clone-safe per-page slices across Workers (`extractPdfPageData` → `toImage`/`encodePng` in Workers, `createPdfContext` + `addPdfPage` on the main thread) — had no way to reach vector ink.

`prepareVectorInkPages`, `buildRenderNoteForVectorInk`, and the `VectorInkPage` type live in `src/vector-ink.ts` but weren't part of the public API. The [Supernote Obsidian plugin](https://github.com/philips/supernote-obsidian-plugin) uses exactly that batched-Worker assembly (to keep pdf-lib's per-page memory cost off the UI thread), so without these exports it can't opt into vector ink the same way a `toPdf` caller already can.

## What

- `src/index.ts`: export `prepareVectorInkPages` and `buildRenderNoteForVectorInk` (values) and `VectorInkPage` (type), alongside the already-exported `StrokeStyle` / `VectorInkPrimitive`.
- `README.md`: add a **"Vector ink from the parallel/Worker path"** subsection right after the existing "Rendering pages in parallel across Workers" block, with a runnable snippet showing `prepareVectorInkPages` → `buildRenderNoteForVectorInk` → `extractPdfPageData(renderNote, n)` → `addPdfPage(..., { strokes, strokeStyles })`.

`addPdfPage` already accepts `strokes`/`strokeStyles` (added with the vector-ink feature), so the only missing piece was the prep entry point. `withoutInkLayers` is intentionally **not** exported — `buildRenderNoteForVectorInk` is the supported way to strip ink layers and returns a proper `ISupernote` that `extractPdfPageData` can slice from directly, so the README sample uses that rather than having callers null out `bitmapBuffer` themselves.

`prepareVectorInkPages` already decides per page whether the decoded strokes are trustworthy enough to replace the rasterized ink (falling back to the raster for any page whose ink doesn't decode or decodes to nothing), so the caller only passes the `strokes`/`strokeStyles` it produced through to `addPdfPage` for pages where `useVectorInk` is true — no per-page heuristics on the consumer side.

## Verification

- `npm run build` clean
- `npm run lint` clean
- `npm test` — 189/189 passing