### PR TITLE
test(visual-diff): automated visual diff for vectorInk PDF output

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,11 @@ jobs:
         with:
           node-version: 20
       - run: npm ci
+      # poppler-utils provides pdftoppm, used by the vectorInk visual-diff
+      # suite (tests/pdf-visual-diff.test.ts) to rasterise PDFs to PNG. It
+      # ships on the GitHub Ubuntu runner, but pinning it explicitly avoids a
+      # silent skip if a future runner image drops it.
+      - run: sudo apt-get update && sudo apt-get install -y poppler-utils
       - run: npm audit --omit=dev --audit-level=high
       - run: npm run lint
       - run: npm run build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,7 @@ A TypeScript library for reading Ratta Supernote `.note` and Atelier `.spd` file
 | Format | `npm run prettier-format` |
 | Clean artifacts | `npm run clean` |
 | Build fixture comparison site | `npm run build:site` (outputs `site/`, type-checked via `tsconfig.scripts.json`) |
+| Regenerate visual-diff baselines | `npm run visual-diff:baseline` (rewrites `tests/visual-diff-baselines.json`) |
 
 **Test framework:** vitest (not jest anymore — README still mentions `npx jest` historically but use vitest).
 
@@ -40,7 +41,7 @@ src/
   mirror.ts      — test helpers / page mirroring
 ```
 
-`scripts/` holds standalone build scripts (e.g. `build-fixture-site.ts`, `pdf-vector.ts`) compiled by `tsconfig.scripts.json`.
+`scripts/` holds standalone build scripts (e.g. `build-fixture-site.ts`, `pdf-vector.ts`, `visual-diff.ts`, `generate-visual-diff-baselines.ts`) compiled by `tsconfig.scripts.json`.
 
 ## Key Architectural Concepts
 
@@ -82,6 +83,10 @@ Binary `.note` files and corresponding device-exported `.pdf` files live in `tes
 `npm run build:site` renders `toSvg({ vectorInk: true })` side-by-side with the device PDF export, page by page. The per-page "ink ratio" is a coarse area-based metric (not unioned), so overlapping strokes from our side read artificially high against merged-device paths — look at the image, not just the number. `sticker-n5-20260016-plugin-artwork` page 2 is the canonical example of this skew.
 
 CI builds the site on PRs as a downloadable artifact; merges to `main` publish to GitHub Pages via `.github/workflows/pages.yml`.
+
+### vectorInk visual-diff suite
+
+`tests/pdf-visual-diff.test.ts` rasterises the library's `toPdf({ vectorInk: true })` output and Supernote's own device PDF per fixture page and compares them with three baselined metrics (`scripts/visual-diff.ts`): an ink-area ratio, an ink-mask IoU (spatial), and a full-page pixel-diff fraction (the one that rasterises the actual PDF and sees colour, including white ink). CI fails on *drift* beyond tolerance, not on absolute correctness — the baselines in `tests/visual-diff-baselines.json` are measurements of the known-good render. Requires `pdftoppm` (poppler-utils); the CI workflow installs it. After an intentional rendering change, regenerate and commit the baselines: `npm run visual-diff:baseline`.
 
 ### Smoke tests
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
       },
       "devDependencies": {
         "@eslint/js": "10.0.1",
+        "@resvg/resvg-js": "^2.6.2",
         "@types/fs-extra": "11.0.4",
         "@types/node": "26.1.1",
         "@types/sql.js": "^1.4.11",
@@ -584,6 +585,234 @@
       "license": "MIT",
       "dependencies": {
         "pako": "^1.0.10"
+      }
+    },
+    "node_modules/@resvg/resvg-js": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js/-/resvg-js-2.6.2.tgz",
+      "integrity": "sha512-xBaJish5OeGmniDj9cW5PRa/PtmuVU3ziqrbr5xJj901ZDN4TosrVaNZpEiLZAxdfnhAe7uQ7QFWfjPe9d9K2Q==",
+      "dev": true,
+      "license": "MPL-2.0",
+      "engines": {
+        "node": ">= 10"
+      },
+      "optionalDependencies": {
+        "@resvg/resvg-js-android-arm-eabi": "2.6.2",
+        "@resvg/resvg-js-android-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-arm64": "2.6.2",
+        "@resvg/resvg-js-darwin-x64": "2.6.2",
+        "@resvg/resvg-js-linux-arm-gnueabihf": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-arm64-musl": "2.6.2",
+        "@resvg/resvg-js-linux-x64-gnu": "2.6.2",
+        "@resvg/resvg-js-linux-x64-musl": "2.6.2",
+        "@resvg/resvg-js-win32-arm64-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-ia32-msvc": "2.6.2",
+        "@resvg/resvg-js-win32-x64-msvc": "2.6.2"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm-eabi": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm-eabi/-/resvg-js-android-arm-eabi-2.6.2.tgz",
+      "integrity": "sha512-FrJibrAk6v29eabIPgcTUMPXiEz8ssrAk7TXxsiZzww9UTQ1Z5KAbFJs+Z0Ez+VZTYgnE5IQJqBcoSiMebtPHA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-android-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-android-arm64/-/resvg-js-android-arm64-2.6.2.tgz",
+      "integrity": "sha512-VcOKezEhm2VqzXpcIJoITuvUS/fcjIw5NA/w3tjzWyzmvoCdd+QXIqy3FBGulWdClvp4g+IfUemigrkLThSjAQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-arm64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-arm64/-/resvg-js-darwin-arm64-2.6.2.tgz",
+      "integrity": "sha512-nmok2LnAd6nLUKI16aEB9ydMC6Lidiiq2m1nEBDR1LaaP7FGs4AJ90qDraxX+CWlVuRlvNjyYJTNv8qFjtL9+A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-darwin-x64": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-darwin-x64/-/resvg-js-darwin-x64-2.6.2.tgz",
+      "integrity": "sha512-GInyZLjgWDfsVT6+SHxQVRwNzV0AuA1uqGsOAW+0th56J7Nh6bHHKXHBWzUrihxMetcFDmQMAX1tZ1fZDYSRsw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm-gnueabihf": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm-gnueabihf/-/resvg-js-linux-arm-gnueabihf-2.6.2.tgz",
+      "integrity": "sha512-YIV3u/R9zJbpqTTNwTZM5/ocWetDKGsro0SWp70eGEM9eV2MerWyBRZnQIgzU3YBnSBQ1RcxRZvY/UxwESfZIw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-gnu/-/resvg-js-linux-arm64-gnu-2.6.2.tgz",
+      "integrity": "sha512-zc2BlJSim7YR4FZDQ8OUoJg5holYzdiYMeobb9pJuGDidGL9KZUv7SbiD4E8oZogtYY42UZEap7dqkkYuA91pg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-arm64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-arm64-musl/-/resvg-js-linux-arm64-musl-2.6.2.tgz",
+      "integrity": "sha512-3h3dLPWNgSsD4lQBJPb4f+kvdOSJHa5PjTYVsWHxLUzH4IFTJUAnmuWpw4KqyQ3NA5QCyhw4TWgxk3jRkQxEKg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-gnu": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-gnu/-/resvg-js-linux-x64-gnu-2.6.2.tgz",
+      "integrity": "sha512-IVUe+ckIerA7xMZ50duAZzwf1U7khQe2E0QpUxu5MBJNao5RqC0zwV/Zm965vw6D3gGFUl7j4m+oJjubBVoftw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-linux-x64-musl": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-linux-x64-musl/-/resvg-js-linux-x64-musl-2.6.2.tgz",
+      "integrity": "sha512-UOf83vqTzoYQO9SZ0fPl2ZIFtNIz/Rr/y+7X8XRX1ZnBYsQ/tTb+cj9TE+KHOdmlTFBxhYzVkP2lRByCzqi4jQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-arm64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-arm64-msvc/-/resvg-js-win32-arm64-msvc-2.6.2.tgz",
+      "integrity": "sha512-7C/RSgCa+7vqZ7qAbItfiaAWhyRSoD4l4BQAbVDqRRsRgY+S+hgS3in0Rxr7IorKUpGE69X48q6/nOAuTJQxeQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-ia32-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-ia32-msvc/-/resvg-js-win32-ia32-msvc-2.6.2.tgz",
+      "integrity": "sha512-har4aPAlvjnLcil40AC77YDIk6loMawuJwFINEM7n0pZviwMkMvjb2W5ZirsNOZY4aDbo5tLx0wNMREp5Brk+w==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@resvg/resvg-js-win32-x64-msvc": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/@resvg/resvg-js-win32-x64-msvc/-/resvg-js-win32-x64-msvc-2.6.2.tgz",
+      "integrity": "sha512-ZXtYhtUr5SSaBrUDq7DiyjOFJqBVL/dOBN7N/qmi/pO0IgiWW/f/ue3nbvu9joWE5aAKDoIzy/CxsY0suwGosQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/package.json
+++ b/package.json
@@ -21,7 +21,8 @@
     "test-mirror": "vitest --watch -t mirror",
     "coverage": "vitest run --coverage",
     "prettier-format": "prettier --config .prettierrc 'src/**/*.ts' --write",
-    "build:site": "tsc -p tsconfig.scripts.json && node .scripts-dist/scripts/build-fixture-site.js"
+    "build:site": "tsc -p tsconfig.scripts.json && node .scripts-dist/scripts/build-fixture-site.js",
+    "visual-diff:baseline": "tsc -p tsconfig.scripts.json && node .scripts-dist/scripts/generate-visual-diff-baselines.js"
   },
   "repository": {
     "type": "git",
@@ -40,6 +41,7 @@
   "homepage": "https://gitlab.com/philips/supernote-typescript",
   "devDependencies": {
     "@eslint/js": "10.0.1",
+    "@resvg/resvg-js": "^2.6.2",
     "@types/fs-extra": "11.0.4",
     "@types/node": "26.1.1",
     "@types/sql.js": "^1.4.11",

--- a/plans/visual-diff-vector-ink-pdf.md
+++ b/plans/visual-diff-vector-ink-pdf.md
@@ -1,0 +1,181 @@
+# Plan: Automated visual diff for vectorInk PDF output
+
+> Issue: https://github.com/philips/supernote-typescript/issues/99
+> Follow-up to #95 / #98 (merged). #98 added `toPdf({ vectorInk: true })`
+> and a three-way fixture comparison site; the only guard on the PDF path
+> today is operator-presence assertions (`tests/pdf.test.ts:190` checks `m`
+> shows up; `:201` checks SVG and PDF share the pipeline). Those pass even
+> if the PDF renders the wrong picture, as long as it emits *some* path
+> operators. This plan closes that gap.
+
+## Context for the implementing agent
+
+This is `supernote-typescript`. Relevant, already-established facts:
+
+- **`toPdf({ vectorInk: true })`** (`src/pdf.ts`) sizes each page in **points** at `pointsPerPixel = 72 / dpi` (default `dpi: 300`, see `ToPdfOptions.dpi`, `src/pdf.ts:63-67`). So a 1404×1872 page (A5X) gets a MediaBox of `1404·72/300 × 1872·72/300 = 337×449` pt.
+- **Supernote's own device PDF exports** size pages in a *different* unit: their MediaBox is literally `[0 0 pageWidth pageHeight]` in page pixels (confirmed in the spike below; also documented in `plans/vector-format-spec.md` under the `thickness` section — `MediaBox 0 0 1920 2560`). So 1 device-PDF point = 1 page pixel; rendering it at **72 DPI** yields exactly `pageWidth × pageHeight` px.
+- The fixture comparison site (`scripts/build-fixture-site.ts`) already pairs every fixture that ships a device `.pdf` with the library's vector-ink SVG and the library's vector-ink PDF, and computes an **ink-area ratio** (`svgInkArea` vs `device.inkArea`). That ratio is area-based, not spatial — it is blind to *where* the ink lands and to colour/order regressions (hatched fills drawn over ink, white cover-ups in the wrong tier, missing contours on a partial erase all read as the same number). `FIXTURE_NOTES` in `build-fixture-site.ts` and the per-fixture notes in it are the catalogue of which regression class each fixture isolates.
+- **`pdf-vector.ts`** (`scripts/`) already turns the device PDF's Form-XObject ink into SVG paths and computes `inkArea` the same way; it is the source of the device-side ground truth on the site. It is build-tooling only, compiled via `tsconfig.scripts.json`, not shipped.
+- CI runs on `ubuntu-latest` (`.github/workflows/test.yml`). `node 20`. `pdftoppm` (poppler-utils) is preinstalled on the GitHub-hosted Ubuntu runner; it is also already present on the dev machine this plan was validated on (`/usr/bin/pdftoppm`).
+
+### Spike already done (don't redo — this de-risks the whole plan)
+
+Ran, on the current tree:
+
+```
+pdftoppm -png -r 72   tests/input/ink-a5x-2.14.28-old-pen-width.pdf /tmp/dev  # → 1404×1872? no: 1920×2560 (that's the heading fixture)
+node -e '…toPdf(sn,{vectorInk:true})…'  && pdftoppm -png -r 300 /tmp/our.pdf /tmp/our300   # → 1404×1872, matching pageWidth/pageHeight
+```
+
+Confirmed:
+1. Device PDF MediaBox == `[0 0 pageWidth pageHeight]`; at 72 DPI `pdftoppm` yields `pageWidth × pageHeight` px.
+2. Library vectorInk PDF at its default `dpi:300`, rendered by `pdftoppm -r 300`, also yields `pageWidth × pageHeight` px.
+3. So both rasters land on the **same canonical pixel grid** with no manual resampling. (Any DPI setting on `toPdf` can be matched by rendering that PDF at `toPdf`'s own `dpi` — i.e. `pdftoppm -r <dpi>` — and the device PDF at 72. The implementation below just renders each at its native DPI and resizes both to a fixed canonical thumbnail, which removes the dependency on the `dpi` knob entirely.)
+4. A coarse 64×64 grayscale thumbnail MAE between the two full-page rasters is a small, stable number (5.52/255 on the one fixture measured), i.e. well inside the band where a real regression (a whole stroke vanishing, a width doubling, a hatched fill landing on top of ink) would push it far outside. This is the metric the tests below pin.
+
+## Goal
+
+A vitest suite that, for every fixture carrying a device `.pdf` export, rasterizes (a) the device PDF and (b) the library's `toPdf({ vectorInk: true })` output to matching-size PNGs, computes a spatial structural-similarity metric, and **fails CI when the metric drifts beyond a per-fixture tolerance** recorded as a committed baseline. This catches the four regression classes the issue names — hatched fills over ink, stroke-width differences, missing/extra contours on partial erases, white ink cover-ups — that the existing operator-level tests structurally cannot, because all four change *where ink is* without necessarily changing *that operators exist*.
+
+A secondary, smaller check compares the library vectorInk PDF raster against the library vectorInk SVG raster (the issue's item 2) so the two pipelines are confirmed to agree, not just to each exist.
+
+## Step-by-step plan
+
+### 1. Pick rasterizers — one system tool, one WASM; no browsers
+
+- **PDF → PNG: `pdftoppm`** (poppler-utils) via `node:child_process` `spawnSync`. It is deterministic, fast, and present on the GitHub runner and the dev box. Avoid `playwright`/`pdfjs-dist` for PDF rasterization — `pdfjs-dist` warns `use the legacy build in Node` and throws on `DOMMatrix` in this Node; a headless browser is a heavy, flaky dependency for one screenshot. `pdftoppm` is the lower-risk choice and the spike already used it.
+- **SVG → PNG: `@resvg/resvg-js`** (WASM, no native build, no system dep). The library's vectorInk SVG is plain `<image>` + `<path>` (no `<text>` in `includeText:false` mode, which is what the comparison uses), well inside resvg's supported subset. Add it as a **devDependency**. (resvg is preferred over `sharp`/libvips because libvips's SVG path goes through librsvg or its own, which varies by build; resvg is one self-contained WASM module with one renderer.)
+
+Neither is a runtime dependency of the shipped package — both are test/build-only, like `pdf-parse` already is.
+
+### 2. CI: install poppler-utils explicitly in the test workflow
+
+`pdftoppm` happens to be on the GitHub Ubuntu runner today, but relying on that is silent breakage waiting to happen (a runner image update could drop it). Add an explicit step to `.github/workflows/test.yml` before `npm test`:
+
+```yaml
+      - run: sudo apt-get update && sudo apt-get install -y poppler-utils
+```
+
+It is the only system dependency the suite adds. (A pure-JS fallback exists in principle — `pdfjs-dist` legacy build + `canvas` npm — but that pulls in native `canvas` bindings, which is a worse CI story than one apt package.)
+
+### 3. New module `scripts/visual-diff.ts` (compiled by `tsconfig.scripts.json`)
+
+It is build tooling, like `pdf-vector.ts`, so it lives under `scripts/` and imports `src/` directly. Exports used by both a CLI regeneration path and the vitest suite:
+
+```ts
+/** One fixture page's three rasters, all resized to the same canonical size. */
+interface PageRasters {
+  fixture: string;
+  pageNumber: number;
+  device: Image;      // device PDF page, full page (background + ink)
+  libraryPdf: Image;   // toPdf({vectorInk:true}) page, full page
+  librarySvg: Image;   // toSvg({vectorInk:true, includeText:false}) page, ink-only over white
+}
+
+/** Render the three sources for one fixture to matched-size grayscale thumbnails. */
+async function rasterizeFixturePage(fixture: string, pageNumber: number, opts?: { dpi?: number }): Promise<PageRasters>
+
+/** Coarse structural-similarity metric in [0,1]: 1 = identical thumbnail.
+ *  Computed on 64×64 grayscale so sub-pixel anti-aliasing between poppler
+ *  and resvg cancels, but a whole stroke moving/removing does not. */
+function thumbnailSimilarity(a: Image, b: Image): number
+
+/** Full-resolution ink-coverage ratio: (#non-background pixels in library)/(# in device).
+ *  A coarse sanity number kept for the same reason build-fixture-site keeps
+ *  its ink-area ratio — catches a whole feature going missing even when the
+ *  thumbnail metric happens to stay flat. */
+function inkCoverageRatio(library: Image, device: Image): number
+```
+
+Implementation notes:
+
+- **Canonical size.** Render each source at its *native* page-pixel size (`pdftoppm -r 72` for the device PDF, `pdftoppm -r <dpi>` for the library PDF where `<dpi>` is the `toPdf` `dpi` option used, resvg at `pageWidth × pageHeight` for the SVG). Then resize all three to the same canonical thumbnail (`64×64` grayscale for the similarity metric; full `pageWidth×pageHeight` grayscale for the coverage ratio) via `image-js` `Image.resize` / grey conversion. This is what removes the DPI/units mismatch the spike surfaced — no source is privileged.
+- **`pdftoppm` invocation:** write the one-page PDF to a temp file (the suite already produces one-page PDFs in `build-fixture-site.ts:buildFixture` via `toPdf(note,{vectorInk:true,pageNumbers:[n]})`; reuse that exact call), then `spawnSync('pdftoppm', ['-png','-r',String(dpi),'-f','1','-l','1', pdfPath, outPrefix])` and read `outPrefix-1.png`. Surface a clear error if `pdftoppm` is missing (message naming the apt package) so the failure is diagnosable rather than an opaque ENOENT.
+- **Background handling for the SVG pane.** `toSvg({vectorInk:true, includeText:false})` embeds the rasterized page background as a base64 `<image>` plus the vector ink paths on top — it is a *full-page* render, matching the device and library-PDF panes, so no compositing is needed; resvg renders the SVG as-is. (This differs from `build-fixture-site`'s `inkOnly()` stripping, which is for that site's like-for-like ink comparison; here we want full pages so PDF-vs-PDF and SVG-vs-PDF are both full-page comparisons.)
+- **`thumbnailSimilarity`** uses a 64×64 grayscale thumbnail, mean abs error, normalised to `1 - mae/255`. SSIM was considered and rejected as the primary metric: it is more sensitive to *texture* (anti-aliasing, dither of the background raster) than to the ink-placement regressions we want to catch, and the spike showed the plain MAE is already stable enough. SSIM can be added as a *secondary* recorded metric if a future regression slips past MAE.
+
+### 4. Baselines under `tests/visual-diff-baselines.json`
+
+One entry per fixture-page-comparison, generated once and committed:
+
+```jsonc
+{
+  "ink-a5x-2.14.28-old-pen-width": {
+    "1": {
+      "pdfVsDeviceSimilarity": 0.978,   // thumbnailSimilarity(libraryPdf, device)
+      "pdfVsDeviceCoverage":   0.84,   // inkCoverageRatio(libraryPdf, device) — ~the 0.84 the spec already records for this fixture
+      "pdfVsSvgSimilarity":    0.999   // thumbnailSimilarity(libraryPdf, librarySvg)
+    }
+  },
+  …
+}
+```
+
+The metric values are not hand-tuned targets — they are **measurements of the current (known-good) render**, recorded so CI catches *drift*, not absolute correctness. This is the same posture `build-fixture-site`'s ink-area ratios take (they are reported, not asserted), except here drift fails CI.
+
+- **Tolerance.** Each asserted metric has a band (default ±0.02 similarity, ±0.10 coverage — wide enough to absorb poppler/resvg point-release anti-aliasing drift, tight enough that a single stroke going missing, a width doubling, or a hatched fill landing on ink trips it; the spike's 5.52/255 MAE ⇒ 0.978 similarity means a regression that moves ~15% of the page reads as similarity ≲ 0.85, well outside the band).
+- **Regeneration.** `npm run visual-diff:baseline` (a new `package.json` script) re-runs `rasterizeFixturePage` for every fixture page, recomputes the metrics, and rewrites `tests/visual-diff-baselines.json`. This is what you run after an *intentional* rendering change; the resulting diff in the baseline file is the review artifact for that change, the same way a `--update` snapshot works.
+
+### 5. New suite `tests/pdf-visual-diff.test.ts`
+
+```ts
+describe('vectorInk PDF visual diff', () => {
+  for (const fixture of FIXTURES_WITH_DEVICE_PDF) {
+    describe(fixture, () => {
+      for (const page of fixturePages(fixture)) {
+        test(`page ${page} matches baseline within tolerance`, async () => {
+          const r = await rasterizeFixturePage(fixture, page);
+          const base = baselines[fixture][String(page)];
+
+          const pdfVsDev = thumbnailSimilarity(r.libraryPdf, r.device);
+          expect(pdfVsDev).toBeGreaterThanOrEqual(base.pdfVsDeviceSimilarity - 0.02);
+
+          const cov = inkCoverageRatio(r.libraryPdf, r.device);
+          expect(cov).toBeGreaterThanOrEqual(base.pdfVsDeviceCoverage - 0.10);
+          expect(cov).toBeLessThanOrEqual(base.pdfVsDeviceCoverage + 0.10);
+
+          const pdfVsSvg = thumbnailSimilarity(r.libraryPdf, r.librarySvg);
+          expect(pdfVsSvg).toBeGreaterThanOrEqual(base.pdfVsSvgSimilarity - 0.02);
+        });
+      }
+    });
+  }
+});
+```
+
+Where `FIXTURES_WITH_DEVICE_PDF` is derived the same way `build-fixture-site.ts:buildFixture` derives its set — iterate `tests/input/*.note`, keep those with a same-stem `.pdf`. Do **not** hardcode the fixture list; reuse that derivation so adding a fixture with a device export adds a visual-diff case for free.
+
+This suite is the one that actually fails CI on a rendering regression — the `m`-operator test in `tests/pdf.test.ts:190` stays as-is (it is the cheap structural guard; this is the spatial one). Expect it to add ~1–2 s × #fixture-pages to the suite (poppler on a single page is sub-100 ms; the spike rendered in well under that).
+
+### 6. Wiring
+
+- `package.json`: add devDeps `@resvg/resvg-js`; add scripts `visual-diff:baseline` (regenerate the JSON) and, if you want a one-shot render-and-dump for eyeballing, `visual-diff:render` (writes the rasters to `tests/output/visual-diff/<fixture>-p<n>-{device,libpdf,libsvg}.png` — mirrors how the image tests already write to `tests/output/`).
+- `.github/workflows/test.yml`: add the `apt-get install -y poppler-utils` step from step 2.
+- `AGENTS.md`: add a row to the Build/Test/Lint table for `npm run visual-diff:baseline`, and a short note in the *Fixture comparison site* section that the visual-diff baselines live in `tests/visual-diff-baselines.json` and must be regenerated (and the diff justified) when a rendering change is intentional — the same discipline the site already implies.
+- `CHANGELOG.md`: note the new CI visual-diff suite under the next version. (No `CHANGELOG.md` existed in the repo; this change is test/CI-internal with no public-API change, so it was skipped. If a changelog is later introduced, record this there.)
+
+## Non-goals
+
+- **No pixel-exact equality assertions.** The two PDFs are produced by different renderers (Ratta's exporter vs this library) and will never be pixel-identical — the spec documents a deliberate ~15–35% width gap on filled-outline exports that no constant corrects without breaking the one exact case (`stroke-n5-…-widths` page 4). Pixel-exact baselines would encode that gap as a "passing" snapshot that still passes when ink regresses onto *different* pixels with the same count. The thumbnail-similarity + coverage-ratio pair is deliberately *not* exact so it catches movement, not just totals.
+- **No per-pixel diff image committed to the repo.** A `visual-diff:render` run can emit one to `tests/output/` for eyeballing, but it is gitignored like the rest of `tests/output/`. The committed artifact is the metrics JSON, which is small and reviewable.
+- **No replacement of `build-fixture-site`'s ink-area ratio.** That ratio stays — it is a fast, renderer-independent sanity number on a published site humans look at. This suite adds *spatial* CI gating that the site cannot (the site is a GitHub Pages artifact, not a test).
+- **No new public API.** `rasterizeFixturePage` etc. live in `scripts/` and are test-only; nothing is exported from `lib/`.
+
+## Open questions the implementing agent should resolve early, not assume
+
+- **Canonical thumbnail size.** 64×64 is the spike's number and is almost certainly fine, but confirm on the densest page in the corpus (`turkish-a6x-20230015-handwriting-erase` page 1, dense handwriting) that a real single-stroke regression still moves the metric outside the ±0.02 band at 64×64. If a stroke is ~2% of page area, a finer grid (e.g. 96×96) may be needed; do not assume 64 is right without measuring on that fixture.
+- **resvg + the SVG's `xlink:href` `<image>`.** resvg supports data-URI images, but confirm the base64 PNG background actually renders (not just the paths) on at least one fixture before building the whole suite on it. If resvg mishandles it, the fallback is to rasterize the background separately via `toImage` (already exported) and composite the SVG's *paths only* on top with resvg — more code, so confirm first.
+- **Whether to skip the SVG-vs-PDF comparison on fixtures where the two are known to differ by design** (the spec notes the SVG centerline fallback differs from the PDF outline path on `sticker-n5-…-plugin-artwork`). If `pdfVsSvgSimilarity` is inherently low on a fixture, record its real baseline rather than a wishful one, and let the tolerance do its job — same discipline as the PDF-vs-device metric.
+- **poppler version drift across runner images.** If a future runner upgrade shifts every baseline by just over the tolerance at once, the fix is to regenerate baselines on the new runner and widen the tolerance slightly — *not* to tighten it, since cross-version poppler anti-aliasing is not the signal. Note this in the baseline file's header comment so the next person knows.
+
+## Implementation outcome (what shipped)
+
+Implemented in `scripts/visual-diff.ts`, `scripts/generate-visual-diff-baselines.ts`, `tests/pdf-visual-diff.test.ts`, `tests/visual-diff-baselines.json` (16 fixtures, 37 pages). Resolved open questions and the deviations from the design above:
+
+- **The 64×64 thumbnail metric was dropped.** Spiking it on `turkish-…-handwriting-erase` p1 showed the full-page thumbnail is dominated by the shared page template (the two PDFs' backgrounds agree almost everywhere), so removing one handwriting line moved similarity by only ~0.006 — *inside* the planned ±0.02 band. It is not sensitive enough to a localized regression. The thumbnail-similarity/coverage-ratio pair from step 3 was replaced by three metrics measured at native `pageWidth × pageHeight` resolution: `inkAreaRatio` (dark-ink pixel ratio of library SVG over device), `iouSvgVsDevice` (IoU of the two ink masks — the spatial one), and `pdfDiffFrac`/`pdfMae` (full-page pixel disagreement between the library PDF and device PDF, thresholded at 40 grey levels so the shared template cancels while ink edges register).
+- **`pdfDiffFrac` is the only metric that rasterises the actual library PDF** (via `pdftoppm`), so it is the one that sees pdf-lib's filled-contour / stroked-centreline / hatched-rect drawing and the only one that sees *colour* — which is what catches a white-ink cover-up the dark-ink masks are blind to. `iouSvgVsDevice` adds the spatial sensitivity the page-level diff lacks; `inkAreaRatio` is the cheap deterministic backbone. A simulated regression (2× ink on `ink-a5x` p1; IoU 0.95 on `turkish` p1 vs the real 0.84) trips the suite with a message naming the drifted metric.
+- **The template-subtraction ink-mask idea (drafted during the spike) was dropped.** `toImage`'s template raster is RGBA with transparency, so it does not cancel cleanly against the RGB PDF render (`pdftoppm` composites the embedded PNG over white), making the derived ink mask unreliable. The full-page `pdfDiffFrac` does not need template isolation — the two PDFs' shared template cancels at the >40-grey-level band by itself.
+- **resvg renders the full-page vectorInk SVG (base64-PNG `<image>` + paths) correctly** — confirmed before building the suite (open question resolved: no fallback needed). The ink-only comparison strips the `<image>` first, the same `inkOnly()` transform `build-fixture-site.ts` uses.
+- **`targetWidth` downsampling was added then defaulted off.** The suite's cost is in rendering (`toPdf`/`toSvg` each call `toImage`), not the pixel math, so downsampling made the suite *slower*, not faster. The option remains for cheap local iteration. Page tests are `test.concurrent` instead, overlapping the per-page rendering across the vitest worker.
+- **Tolerances** (`scripts/visual-diff.ts` `DEFAULT_TOLERANCE`): `inkAreaRatio ±0.08`, `iouSvgVsDevice ±0.03`, `pdfDiffFrac ±max(15% of baseline, 0.003)`; pages where the device draws no ink assert `ourInkPixels` stays below a 500-px floor (no phantom ink on blank pages) instead of a meaningless ratio.
+- **CI**: `.github/workflows/test.yml` pins `poppler-utils` explicitly before `npm test`. `package.json` adds `@resvg/resvg-js` (devDep) and a `visual-diff:baseline` script. `AGENTS.md` documents the suite and the regenerate discipline. Full suite: 228 tests (189 + 39 new), ~152 s wall — the new file adds ~30 s wall thanks to the 2-worker pool overlapping it with the other files.

--- a/scripts/generate-visual-diff-baselines.ts
+++ b/scripts/generate-visual-diff-baselines.ts
@@ -1,0 +1,40 @@
+/**
+ * Regenerates `tests/visual-diff-baselines.json` from the current render.
+ *
+ * Run after an *intentional* rendering change; the resulting diff in the
+ * baseline file is the review artifact for that change, the way `--update`
+ * snapshots are.
+ *
+ *   npm run visual-diff:baseline
+ */
+
+import * as fs from 'node:fs';
+import { listFixturesWithDevicePdf, computeMetrics, type VisualDiffMetrics } from './visual-diff.js';
+
+const OUT_FILE = 'tests/visual-diff-baselines.json';
+
+async function main() {
+	const fixtures = await listFixturesWithDevicePdf();
+	const baselines: Record<string, Record<string, VisualDiffMetrics>> = {};
+	let totalPages = 0;
+	for (const { name, pages } of fixtures) {
+		const pageMap: Record<string, VisualDiffMetrics> = {};
+		for (let p = 1; p <= pages; p++) {
+			const m = await computeMetrics(`${name}.note`, p);
+			pageMap[String(p)] = m;
+			totalPages++;
+			console.log(`${name} p${p}: ink=${m.ourInkPixels}/${m.deviceInkPixels} iou=${m.iouSvgVsDevice.toFixed(3)} pdfDiff=${m.pdfDiffFrac.toFixed(4)}`);
+		}
+		baselines[name] = pageMap;
+	}
+	// Pure JSON (no comment header -- JSON does not allow comments). The
+	// regenerate command and the drift-not-targets intent are documented in
+	// tests/pdf-visual-diff.test.ts and AGENTS.md.
+	fs.writeFileSync(OUT_FILE, JSON.stringify(baselines, null, 2) + '\n');
+	console.log(`wrote ${OUT_FILE}: ${fixtures.length} fixtures, ${totalPages} pages`);
+}
+
+main().catch((err) => {
+	console.error(err);
+	process.exit(1);
+});

--- a/scripts/visual-diff.ts
+++ b/scripts/visual-diff.ts
@@ -1,0 +1,365 @@
+/**
+ * Visual-diff metrics for `toPdf({ vectorInk: true })`, used by
+ * `tests/pdf-visual-diff.test.ts` to catch rendering regressions the
+ * operator-level PDF tests cannot.
+ *
+ * For every fixture that ships a device `.pdf` export, each page is measured
+ * three ways against ground truth (Supernote's own vector PDF export):
+ *
+ * 1. `inkAreaRatio` — dark-ink pixel count of the library's vector-ink SVG
+ *    over the device's, both rasterised ink-only. Deterministic and
+ *    renderer-independent in shape; catches a whole stroke going missing or
+ *    a width doubling. (Pure-white eraser overlays are excluded by the
+ *    dark-ink threshold, the same convention `build-fixture-site.ts`'s
+ *    `svgInkArea` uses.)
+ * 2. `iouSvgVsDevice` — intersection-over-union of the two ink masks. A
+ *    spatial metric, sensitive to *where* the ink lands: a hatched fill
+ *    drawn over nearby ink, an extra contour on a partial erase, or a stroke
+ *    shifted all drop IoU even when total area barely moves.
+ * 3. `pdfDiffFrac` / `pdfMae` — rasterise the library's `toPdf({vectorInk:
+ *    true})` page and the device PDF page to PNGs (via `pdftoppm`) and
+ *    compare full pages. Both share the same page template as their
+ *    background, so the template cancels at the >40-grey-level band the diff
+ *    counts; what is left is ink the two sides disagree on. This is the one
+ *    metric that rasterises the actual library PDF (so it sees pdf-lib's
+ *    filled-contour / stroked-centreline / hatched-rect drawing, not just the
+ *    shared `vector-ink.ts` pipeline) and the only one that sees *colour*,
+ *    which is what catches a white-ink cover-up the dark-ink masks above are
+ *    blind to.
+ *
+ * Metric values are not targets — they are measurements of the known-good
+ * render, recorded in `tests/visual-diff-baselines.json` so CI fails on
+ * *drift*, not on absolute correctness. This is the same posture
+ * `build-fixture-site.ts`'s ink-area ratio takes (reported, not asserted),
+ * except here a regression fails CI.
+ *
+ * Build tooling, not shipped: lives under `scripts/` and is compiled by
+ * `tsconfig.scripts.json`. Needs `pdftoppm` (poppler-utils) on PATH and
+ * `@resvg/resvg-js` (devDependency) for SVG rasterisation.
+ */
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+import { spawnSync } from 'node:child_process';
+import { decode } from 'image-js';
+import { Resvg } from '@resvg/resvg-js';
+import { SupernoteX } from '../src/parsing.js';
+import { toSvg } from '../src/svg.js';
+import { toPdf } from '../src/pdf.js';
+import { extractPageForms, pdfPageToSvg, devicePageToSvgDocument } from './pdf-vector.js';
+
+const INPUT_DIR = 'tests/input';
+
+/** A pixel value below this is "ink" (dark) on the ink-only rasters. Pure
+ * white (254, the white-pen cover-up colour) is deliberately above it, so
+ * white cover-ups are not counted as ink — matching `build-fixture-site.ts`'s
+ * `svgInkArea`, which skips `rgb(255,255,255)` for the same reason. */
+const INK_GREY_THRESHOLD = 200;
+/** Two full-page pixels this many grey levels apart count as a disagreement.
+ * Chosen (measured on the fixtures) to sit above the template-background
+ * compression noise between our decode and the device's embedded image, so
+ * the template cancels, and below real ink-edge differences, so ink the two
+ * sides disagree on registers. */
+const PAGE_DIFF_THRESHOLD = 40;
+
+export interface VisualDiffMetrics {
+	/** Library SVG dark-ink pixel count divided by the device's. `null` when
+	 * the device draws no ink on the page — then `ourInkPixels`/`deviceInkPixels`
+	 * are what the test checks, not the ratio. */
+	inkAreaRatio: number | null;
+	/** IoU of the library-SVG ink mask and the device ink mask, in [0,1].
+	 * Returns 1 when both masks are empty (both sides agree the page is
+	 * blank). */
+	iouSvgVsDevice: number;
+	/** Fraction of full-page pixels where the library PDF and device PDF
+	 * differ by more than `PAGE_DIFF_THRESHOLD` grey levels. */
+	pdfDiffFrac: number;
+	/** Mean absolute grey-level difference over the full page. Recorded as
+	 * a sanity number; the test asserts `pdfDiffFrac`, not this. */
+	pdfMae: number;
+	/** Dark-ink pixel count the library SVG laid down. */
+	ourInkPixels: number;
+	/** Dark-ink pixel count the device PDF laid down. */
+	deviceInkPixels: number;
+}
+
+export interface FixturePageKey {
+	/** Fixture name without extension, e.g. `ink-a5x-2.14.28-old-pen-width`. */
+	fixture: string;
+	pageNumber: number;
+}
+
+/** Every fixture in `tests/input` that ships a same-stem `.pdf` device export,
+ * with its page count. Derived the same way `build-fixture-site.ts:buildFixture`
+ * derives its set, so adding a fixture with a device export adds a visual-diff
+ * case automatically. */
+export async function listFixturesWithDevicePdf(inputDir: string = INPUT_DIR): Promise<{ name: string; pages: number }[]> {
+	const files = (await fs.promises.readdir(inputDir)).filter((f) => f.endsWith('.note')).sort();
+	const out: { name: string; pages: number }[] = [];
+	for (const file of files) {
+		const name = file.replace(/\.note$/, '');
+		try {
+			await fs.promises.access(path.join(inputDir, `${name}.pdf`));
+		} catch {
+			continue;
+		}
+		const note = new SupernoteX(new Uint8Array(await fs.promises.readFile(path.join(inputDir, file))));
+		out.push({ name, pages: note.pages.length });
+	}
+	return out;
+}
+
+/** The red channel as a `Float32Array` of length `width*height`. Using a single
+ * channel (rather than `image.grey()`) keeps the library-PDF render (RGB) and
+ * the resvg/`toImage` renders (RGBA) comparable — `grey()` weights channels
+ * differently for 3- vs 4-channel images, which would make two renders of the
+ * same page read as different everywhere. Red is fine: ink is dark in every
+ * channel and the page template is near-white. */
+type DecodedImage = { width: number; height: number; channels: number; data: Uint8Array | Uint8ClampedArray; resize: (opts: { width: number; height: number }) => DecodedImage };
+
+function redPlane(img: DecodedImage): Float32Array {
+	const n = img.width * img.height;
+	const out = new Float32Array(n);
+	const ch = img.channels;
+	for (let i = 0; i < n; i++) out[i] = img.data[i * ch];
+	return out;
+}
+
+function rasterizePdf(pdfPath: string, dpi: number, outPrefix: string): DecodedImage {
+	const res = spawnSync('pdftoppm', ['-png', '-r', String(dpi), '-f', '1', '-l', '1', pdfPath, outPrefix], { stdio: 'pipe' });
+	if (res.status !== 0) {
+		const hint = res.error?.message?.includes('ENOENT') ? ' (is poppler-utils / pdftoppm installed?)' : '';
+		throw new Error(`pdftoppm failed for ${path.basename(pdfPath)}: ${(res.stderr ?? '').toString().trim()}${hint}`);
+	}
+	return decode(fs.readFileSync(`${outPrefix}-1.png`)) as unknown as DecodedImage;
+}
+
+function rasterizeSvgInkOnly(svg: string, width: number): DecodedImage {
+	const png = new Resvg(svg, { fitTo: { mode: 'width', value: width }, background: 'white' }).render().asPng();
+	return decode(Buffer.from(png)) as unknown as DecodedImage;
+}
+
+/** Downsample to a canonical width, preserving aspect ratio. All four
+ * rasters share the page's aspect ratio, so they all land on the same
+ * `targetWidth x targetHeight` grid without any per-source resampling arg. */
+function resizeToWidth(img: DecodedImage, targetWidth: number | undefined): DecodedImage {
+	if (targetWidth === undefined || img.width === targetWidth) return img;
+	const targetHeight = Math.round((targetWidth * img.height) / img.width);
+	return img.resize({ width: targetWidth, height: targetHeight });
+}
+
+function inkMask(plane: Float32Array, threshold = INK_GREY_THRESHOLD): Uint8Array {
+	const mask = new Uint8Array(plane.length);
+	for (let i = 0; i < plane.length; i++) if (plane[i] < threshold) mask[i] = 1;
+	return mask;
+}
+
+function maskArea(mask: Uint8Array): number {
+	let c = 0;
+	for (const v of mask) c += v;
+	return c;
+}
+
+function iou(a: Uint8Array, b: Uint8Array): number {
+	let inter = 0;
+	let uni = 0;
+	for (let i = 0; i < a.length; i++) {
+		const x = a[i];
+		const y = b[i];
+		if (x || y) {
+			uni++;
+			if (x && y) inter++;
+		}
+	}
+	return uni ? inter / uni : 1; // both empty => both agree the page is blank
+}
+
+function pageDiffStats(a: Float32Array, b: Float32Array, threshold = PAGE_DIFF_THRESHOLD): { diffFrac: number; mae: number } {
+	const n = a.length;
+	let over = 0;
+	let mae = 0;
+	for (let i = 0; i < n; i++) {
+		const d = Math.abs(a[i] - b[i]);
+		if (d > threshold) over++;
+		mae += d;
+	}
+	return { diffFrac: over / n, mae: mae / n };
+}
+
+/** Strip the rasterized page background from a vectorInk SVG so only ink is
+ * left — the same `inkOnly()` transform `build-fixture-site.ts` uses, so the
+ * ink-only rasters here compare like-for-like with that site. */
+function inkOnlySvg(svg: string): string {
+	return svg.replace(/<image\b[^>]*\/>/g, '');
+}
+
+export interface ComputeMetricsOptions {
+	/** DPI passed to `toPdf`; the library PDF is rasterised at this DPI so its
+	 * pixels come out at `pageWidth x pageHeight`. Defaults to 300 (`toPdf`'s
+	 * own default). */
+	dpi?: number;
+	/** Directory for intermediate PNG/PDF files. Defaults to a fresh temp
+	 * dir created and removed per call. */
+	workDir?: string;
+	/** Canonical width all four rasters are downsampled to before the masks
+	 * and diffs are computed. Omit (or pass `undefined`) to keep each raster at
+	 * its native `pageWidth x pageHeight` -- the default, since the suite's
+	 * cost is in rendering (`toPdf`/`toSvg` each call `toImage`), not in the
+	 * pixel math, so downsampling did not pay off. Pass a smaller width only
+	 * to trade a little metric sharpness for cheaper local iteration. */
+	targetWidth?: number;
+}
+
+/**
+ * Compute the visual-diff metrics for one fixture page.
+ *
+ * Rasterises four things: the library `toPdf({vectorInk:true})` page, the
+ * device PDF page (both via `pdftoppm`), the device's vector ink (via
+ * `pdf-vector.ts` -> resvg), and the library's vector-ink SVG ink-only (via
+ * resvg). All four land on the `pageWidth x pageHeight` pixel grid, so the
+ * masks and diffs are aligned without any resampling.
+ */
+export async function computeMetrics(noteFile: string, pageNumber: number, options: ComputeMetricsOptions = {}): Promise<VisualDiffMetrics> {
+	const dpi = options.dpi ?? 300;
+	const targetWidth = options.targetWidth; // undefined => native, no resize
+	const notePath = path.isAbsolute(noteFile) ? noteFile : path.join(INPUT_DIR, noteFile);
+	const noteName = path.basename(notePath, '.note');
+	const devicePdfPath = path.join(path.dirname(notePath), `${noteName}.pdf`);
+
+	const sn = new SupernoteX(new Uint8Array(fs.readFileSync(notePath)));
+	const W = sn.pageWidth;
+	const H = sn.pageHeight;
+
+	const ownsWorkDir = !options.workDir;
+	const workDir = options.workDir ?? fs.mkdtempSync(path.join(os.tmpdir(), 'supernote-visualdiff-'));
+	try {
+		// 1. Library vector-ink PDF, rasterised.
+		const ourPdfBytes = await toPdf(sn, { vectorInk: true, pageNumbers: [pageNumber], dpi });
+		const ourPdfPath = path.join(workDir, 'our.pdf');
+		fs.writeFileSync(ourPdfPath, ourPdfBytes);
+		const libPdfPlane = redPlane(resizeToWidth(rasterizePdf(ourPdfPath, dpi, path.join(workDir, 'our')), targetWidth));
+
+		// 2. Device PDF, rasterised at 72 DPI (its MediaBox is in page pixels, so
+		//    72 DPI yields exactly pageWidth x pageHeight), then downsampled to
+		//    the same canonical width as the others.
+		const devPlane = redPlane(resizeToWidth(rasterizePdf(devicePdfPath, 72, path.join(workDir, 'dev')), targetWidth));
+
+		// 3. Device vector ink only: extract the Form-XObject ink the device's
+		//    PDF carries and rasterise it over white. Rasterise at the full page
+		//    width then downsample so the ink edges anti-alias the same way the
+		//    full-page rasters do.
+		const forms = extractPageForms(fs.readFileSync(devicePdfPath));
+		const devInkSvg = devicePageToSvgDocument(pdfPageToSvg(forms[pageNumber - 1] ?? [], H), W, H);
+		const devInkPlane = redPlane(resizeToWidth(rasterizeSvgInkOnly(devInkSvg, W), targetWidth));
+
+		// 4. Library vector-ink SVG, ink only, rasterised over white.
+		const [ourSvgFull] = await toSvg(sn, { vectorInk: true, includeText: false, pageNumbers: [pageNumber] });
+		const ourInkPlane = redPlane(resizeToWidth(rasterizeSvgInkOnly(inkOnlySvg(ourSvgFull), W), targetWidth));
+
+		const devInkMask = inkMask(devInkPlane);
+		const ourInkMask = inkMask(ourInkPlane);
+		const deviceInkPixels = maskArea(devInkMask);
+		const ourInkPixels = maskArea(ourInkMask);
+
+		const pd = pageDiffStats(libPdfPlane, devPlane);
+		return {
+			inkAreaRatio: deviceInkPixels > 0 ? ourInkPixels / deviceInkPixels : null,
+			iouSvgVsDevice: iou(ourInkMask, devInkMask),
+			pdfDiffFrac: pd.diffFrac,
+			pdfMae: pd.mae,
+			ourInkPixels,
+			deviceInkPixels,
+		};
+	} finally {
+		if (ownsWorkDir) fs.rmSync(workDir, { recursive: true, force: true });
+	}
+}
+
+/** Tolerance applied to each metric by the test. Wide enough to absorb
+ * poppler/resvg point-release anti-aliasing drift, tight enough that a single
+ * whole stroke going missing, a width doubling, or a hatched fill landing on
+ * ink trips it. Tuned from the measured per-fixture baselines. */
+export interface VisualDiffTolerance {
+	inkAreaRatio: number; // absolute band, applied only when device has ink
+	iouSvgVsDevice: number; // absolute band
+	pdfDiffFracRelative: number; // e.g. 0.15 => +/-15% of baseline
+	pdfDiffFracAbsolute: number; // floor added to the relative band for tiny baselines
+	blankInkPixelFloor: number; // a "blank" device page must keep our ink below this
+}
+
+export const DEFAULT_TOLERANCE: VisualDiffTolerance = {
+	inkAreaRatio: 0.08,
+	iouSvgVsDevice: 0.03,
+	pdfDiffFracRelative: 0.15,
+	pdfDiffFracAbsolute: 0.003,
+	blankInkPixelFloor: 500,
+};
+
+/** One baseline's pass/fail verdict, with the value that crossed for the
+ * failure message. */
+export interface MetricCheck {
+	metric: string;
+	baseline: number | null;
+	actual: number | null;
+	pass: boolean;
+	message: string;
+}
+
+/** Compare a measured page against its recorded baseline. Pure (no I/O) so
+ * the test can call it directly. */
+export function checkAgainstBaseline(actual: VisualDiffMetrics, baseline: VisualDiffMetrics, tol: VisualDiffTolerance = DEFAULT_TOLERANCE): MetricCheck[] {
+	const checks: MetricCheck[] = [];
+	const add = (metric: string, pass: boolean, message: string) => checks.push({ metric, baseline: null, actual: null, pass, message });
+
+	if (baseline.deviceInkPixels < tol.blankInkPixelFloor) {
+		// The device draws ~nothing on this page. The right assertion is that
+		// we also draw ~nothing (no phantom ink), not an area ratio.
+		const pass = actual.ourInkPixels < tol.blankInkPixelFloor;
+		checks.push({
+			metric: 'ourInkPixels',
+			baseline: baseline.ourInkPixels,
+			actual: actual.ourInkPixels,
+			pass,
+			message: `device draws no ink; expected ourInkPixels < ${tol.blankInkPixelFloor}, got ${actual.ourInkPixels}`,
+		});
+	} else {
+		const ar = actual.inkAreaRatio;
+		const bar = baseline.inkAreaRatio;
+		if (ar === null) {
+			add('inkAreaRatio', false, `device has ink but our inkAreaRatio is null`);
+		} else if (bar === null) {
+			add('inkAreaRatio', false, `baseline inkAreaRatio is null but device now has ${baseline.deviceInkPixels} ink px`);
+		} else {
+			const pass = Math.abs(ar - bar) <= tol.inkAreaRatio;
+			checks.push({
+				metric: 'inkAreaRatio',
+				baseline: bar,
+				actual: ar,
+				pass,
+				message: `inkAreaRatio ${ar.toFixed(3)} vs baseline ${bar.toFixed(3)} (±${tol.inkAreaRatio})`,
+			});
+		}
+	}
+
+	const iouPass = Math.abs(actual.iouSvgVsDevice - baseline.iouSvgVsDevice) <= tol.iouSvgVsDevice;
+	checks.push({
+		metric: 'iouSvgVsDevice',
+		baseline: baseline.iouSvgVsDevice,
+		actual: actual.iouSvgVsDevice,
+		pass: iouPass,
+		message: `iouSvgVsDevice ${actual.iouSvgVsDevice.toFixed(3)} vs baseline ${baseline.iouSvgVsDevice.toFixed(3)} (±${tol.iouSvgVsDevice})`,
+	});
+
+	const band = Math.max(baseline.pdfDiffFrac * tol.pdfDiffFracRelative, tol.pdfDiffFracAbsolute);
+	const pdfPass = Math.abs(actual.pdfDiffFrac - baseline.pdfDiffFrac) <= band;
+	checks.push({
+		metric: 'pdfDiffFrac',
+		baseline: baseline.pdfDiffFrac,
+		actual: actual.pdfDiffFrac,
+		pass: pdfPass,
+		message: `pdfDiffFrac ${actual.pdfDiffFrac.toFixed(4)} vs baseline ${baseline.pdfDiffFrac.toFixed(4)} (±${band.toFixed(4)})`,
+	});
+
+	return checks;
+}

--- a/tests/pdf-visual-diff.test.ts
+++ b/tests/pdf-visual-diff.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Visual-diff regression test for `toPdf({ vectorInk: true })`.
+ *
+ * For every fixture that ships a device `.pdf` export, each page is rendered
+ * three ways and measured against Supernote's own vector PDF export (ground
+ * truth); the metrics are checked against committed baselines in
+ * `tests/visual-diff-baselines.json`. CI fails on *drift* beyond tolerance,
+ * not on absolute correctness — the values are measurements of the known-good
+ * render, the way `--update` snapshots are.
+ *
+ * Three metrics (see `scripts/visual-diff.ts` for the full rationale):
+ *   - `inkAreaRatio`   dark-ink pixel count of our SVG over the device's.
+ *   - `iouSvgVsDevice` intersection-over-union of the two ink masks (spatial).
+ *   - `pdfDiffFrac`    full-page pixel disagreement between our vectorInk PDF
+ *                     and the device PDF (the one metric that rasterises the
+ *                     actual library PDF and sees colour, incl. white ink).
+ *
+ * Requires `pdftoppm` (poppler-utils) on PATH. The CI workflow installs it;
+ * locally run `apt-get install poppler-utils` (or your platform's equivalent).
+ *
+ * After an intentional rendering change, regenerate the baselines and commit
+ * the diff:
+ *
+ *   npm run visual-diff:baseline
+ */
+
+import * as fs from 'fs-extra';
+import { spawnSync } from 'node:child_process';
+import { describe, test, expect } from 'vitest';
+import { listFixturesWithDevicePdf, computeMetrics, checkAgainstBaseline, type VisualDiffMetrics } from '../scripts/visual-diff';
+
+const BASELINES = JSON.parse(fs.readFileSync('tests/visual-diff-baselines.json', 'utf8')) as Record<string, Record<string, VisualDiffMetrics>>;
+
+// Top-level await: the describe blocks below need the fixture list, and
+// vitest supports top-level await in test modules. This runs once at load.
+const FIXTURES = await listFixturesWithDevicePdf();
+
+describe('vectorInk PDF visual diff', () => {
+	test('pdftoppm (poppler-utils) is installed', () => {
+		// Fail loudly and early with a named package rather than an opaque
+		// ENOENT deep inside rasterizePdf, so a missing CI dep is obvious.
+		const r = spawnSync('pdftoppm', ['-v'], { stdio: 'pipe' });
+		expect(r.error, 'pdftoppm not found — install poppler-utils').toBeUndefined();
+	});
+
+	test('baseline set covers every fixture page with a device export', () => {
+		// Catches a fixture being added with a device PDF but no baseline being
+		// regenerated — the new pages would silently be un-tested — and a
+		// baseline lingering after its fixture was removed.
+		for (const { name, pages } of FIXTURES) {
+			const base = BASELINES[name];
+			expect(base, `${name}: no baseline entry (run: npm run visual-diff:baseline)`).toBeDefined();
+			for (let p = 1; p <= pages; p++) {
+				expect(base[String(p)], `${name} page ${p}: no baseline`).toBeDefined();
+			}
+		}
+		for (const fixture of Object.keys(BASELINES)) {
+			expect(FIXTURES.some((f) => f.name === fixture), `${fixture}.pdf has a baseline but no fixture/device PDF`).toBe(true);
+		}
+	});
+
+	for (const { name, pages } of FIXTURES) {
+		describe(name, () => {
+			for (let p = 1; p <= pages; p++) {
+				// Concurrent so the per-page rendering (the suite's cost: each page
+				// runs toPdf/toSvg, which each call toImage) overlaps across pages
+				// instead of running strictly serially. `concurrent: true` keeps
+				// each page's failure message isolated to that page.
+				test.concurrent(`page ${p} matches baseline`, { timeout: 60000 }, async () => {
+					const baseline = BASELINES[name]?.[String(p)];
+					expect(baseline, `${name} page ${p}: missing baseline`).toBeDefined();
+					const actual = await computeMetrics(`${name}.note`, p);
+					const failures = checkAgainstBaseline(actual, baseline).filter((c) => !c.pass);
+					if (failures.length > 0) {
+						// One assertion listing every metric that drifted, so the
+						// failure points at the regression, not just one metric.
+						expect.fail(
+							`${name} page ${p} regressed:\n` +
+								failures.map((c) => `  - ${c.message}`).join('\n') +
+								'\nIf this is an intentional rendering change, regenerate: `npm run visual-diff:baseline`',
+						);
+					}
+				});
+			}
+		});
+	}
+});

--- a/tests/visual-diff-baselines.json
+++ b/tests/visual-diff-baselines.json
@@ -1,0 +1,330 @@
+{
+  "blank-a6x-3.15.27-shapes-rtr": {
+    "1": {
+      "inkAreaRatio": 0.9144807415019147,
+      "iouSvgVsDevice": 0.8818879222572809,
+      "pdfDiffFrac": 0.0309962226361799,
+      "pdfMae": 5.3384309482065895,
+      "ourInkPixels": 445856,
+      "deviceInkPixels": 487551
+    }
+  },
+  "blank-a6x-3.26.40-two-pages": {
+    "1": {
+      "inkAreaRatio": null,
+      "iouSvgVsDevice": 1,
+      "pdfDiffFrac": 0,
+      "pdfMae": 0,
+      "ourInkPixels": 0,
+      "deviceInkPixels": 0
+    },
+    "2": {
+      "inkAreaRatio": null,
+      "iouSvgVsDevice": 1,
+      "pdfDiffFrac": 0,
+      "pdfMae": 0,
+      "ourInkPixels": 0,
+      "deviceInkPixels": 0
+    }
+  },
+  "caligraphy-n5-20260016-widths-erase": {
+    "1": {
+      "inkAreaRatio": 0.7044995767402488,
+      "iouSvgVsDevice": 0.6881751636516075,
+      "pdfDiffFrac": 0.003184611002604167,
+      "pdfMae": 0.41809672037760415,
+      "ourInkPixels": 21638,
+      "deviceInkPixels": 30714
+    },
+    "2": {
+      "inkAreaRatio": 0.7719706461428316,
+      "iouSvgVsDevice": 0.7583744804802671,
+      "pdfDiffFrac": 0.013116658528645833,
+      "pdfMae": 1.9775628662109375,
+      "ourInkPixels": 21565,
+      "deviceInkPixels": 27935
+    },
+    "3": {
+      "inkAreaRatio": 0.8257000383582662,
+      "iouSvgVsDevice": 0.8168261400651465,
+      "pdfDiffFrac": 0.01641845703125,
+      "pdfMae": 2.5059521484375,
+      "ourInkPixels": 32289,
+      "deviceInkPixels": 39105
+    },
+    "4": {
+      "inkAreaRatio": 0.8657573582196698,
+      "iouSvgVsDevice": 0.8614811631571409,
+      "pdfDiffFrac": 0.008719278971354166,
+      "pdfMae": 1.5059547932942707,
+      "ourInkPixels": 6030,
+      "deviceInkPixels": 6965
+    }
+  },
+  "erase-n5-20260016-all-mechanisms": {
+    "1": {
+      "inkAreaRatio": null,
+      "iouSvgVsDevice": 1,
+      "pdfDiffFrac": 0,
+      "pdfMae": 0.044404703776041665,
+      "ourInkPixels": 0,
+      "deviceInkPixels": 0
+    }
+  },
+  "erase-n5-20260016-mixed-colors": {
+    "1": {
+      "inkAreaRatio": 0.9739931262611836,
+      "iouSvgVsDevice": 0.9678644584676716,
+      "pdfDiffFrac": 0.002136433919270833,
+      "pdfMae": 0.3413108317057292,
+      "ourInkPixels": 211413,
+      "deviceInkPixels": 217058
+    },
+    "2": {
+      "inkAreaRatio": 0.9638037714599827,
+      "iouSvgVsDevice": 0.9573480773727993,
+      "pdfDiffFrac": 0.09418558756510417,
+      "pdfMae": 13.298054606119791,
+      "ourInkPixels": 287547,
+      "deviceInkPixels": 298346
+    }
+  },
+  "erase-n5-20260016-no-white-pen": {
+    "1": {
+      "inkAreaRatio": null,
+      "iouSvgVsDevice": 1,
+      "pdfDiffFrac": 0,
+      "pdfMae": 0,
+      "ourInkPixels": 0,
+      "deviceInkPixels": 0
+    }
+  },
+  "erase-n5-20260016-white-pen-cover": {
+    "1": {
+      "inkAreaRatio": 0.8678644895860118,
+      "iouSvgVsDevice": 0.8425174381737476,
+      "pdfDiffFrac": 0.0016794840494791666,
+      "pdfMae": 0.26074422200520836,
+      "ourInkPixels": 27001,
+      "deviceInkPixels": 31112
+    },
+    "2": {
+      "inkAreaRatio": 0.9756188696870621,
+      "iouSvgVsDevice": 0.9707219799470722,
+      "pdfDiffFrac": 0.016029459635416667,
+      "pdfMae": 3.935401814778646,
+      "ourInkPixels": 52220,
+      "deviceInkPixels": 53525
+    },
+    "3": {
+      "inkAreaRatio": 0.8815685499802449,
+      "iouSvgVsDevice": 0.8460837710542127,
+      "pdfDiffFrac": 0.0154681396484375,
+      "pdfMae": 3.672197265625,
+      "ourInkPixels": 44625,
+      "deviceInkPixels": 50620
+    },
+    "4": {
+      "inkAreaRatio": 1.0093691216900593,
+      "iouSvgVsDevice": 0.900277103075502,
+      "pdfDiffFrac": 0.012076416015625,
+      "pdfMae": 2.8687925211588543,
+      "ourInkPixels": 27903,
+      "deviceInkPixels": 27644
+    }
+  },
+  "erase-n6-20230015-horizontal-1270": {
+    "1": {
+      "inkAreaRatio": 0.9876726376191827,
+      "iouSvgVsDevice": 0.8457564276597038,
+      "pdfDiffFrac": 0.007228279397082816,
+      "pdfMae": 0.9155050740253732,
+      "ourInkPixels": 45268,
+      "deviceInkPixels": 45833
+    }
+  },
+  "heading-n5-20260016-backgrounds-marker": {
+    "1": {
+      "inkAreaRatio": 0.9748005571736102,
+      "iouSvgVsDevice": 0.862534336557984,
+      "pdfDiffFrac": 0.0010194905598958333,
+      "pdfMae": 0.11738362630208334,
+      "ourInkPixels": 15396,
+      "deviceInkPixels": 15794
+    },
+    "2": {
+      "inkAreaRatio": 1.033017742563317,
+      "iouSvgVsDevice": 0.8971386053923579,
+      "pdfDiffFrac": 0.0434112548828125,
+      "pdfMae": 6.498640950520834,
+      "ourInkPixels": 164537,
+      "deviceInkPixels": 159278
+    },
+    "3": {
+      "inkAreaRatio": 0.9779551826723455,
+      "iouSvgVsDevice": 0.972018123492969,
+      "pdfDiffFrac": 0.04253499348958333,
+      "pdfMae": 6.290022786458334,
+      "ourInkPixels": 137079,
+      "deviceInkPixels": 140169
+    }
+  },
+  "ink-a5x-2.14.28-old-pen-width": {
+    "1": {
+      "inkAreaRatio": 0.8254452522931236,
+      "iouSvgVsDevice": 0.8172011201830158,
+      "pdfDiffFrac": 0.005993635400686682,
+      "pdfMae": 0.7522451877419826,
+      "ourInkPixels": 41666,
+      "deviceInkPixels": 50477
+    }
+  },
+  "line-n5-20260016-ruler-tool": {
+    "1": {
+      "inkAreaRatio": 1.132088736134979,
+      "iouSvgVsDevice": 0.8230697301629709,
+      "pdfDiffFrac": 0.002212320963541667,
+      "pdfMae": 0.2609708658854167,
+      "ourInkPixels": 28986,
+      "deviceInkPixels": 25604
+    },
+    "2": {
+      "inkAreaRatio": 1.1074399260628467,
+      "iouSvgVsDevice": 0.9017931609674729,
+      "pdfDiffFrac": 0.007190348307291667,
+      "pdfMae": 1.7073118082682293,
+      "ourInkPixels": 9586,
+      "deviceInkPixels": 8656
+    },
+    "3": {
+      "inkAreaRatio": null,
+      "iouSvgVsDevice": 1,
+      "pdfDiffFrac": 0.00527099609375,
+      "pdfMae": 1.2582645670572916,
+      "ourInkPixels": 0,
+      "deviceInkPixels": 0
+    }
+  },
+  "link-n6-3.26.40-partial-erase-3p": {
+    "1": {
+      "inkAreaRatio": 0.7232233488686844,
+      "iouSvgVsDevice": 0.7119373692029103,
+      "pdfDiffFrac": 0.01289622750627024,
+      "pdfMae": 2.16271732778143,
+      "ourInkPixels": 66261,
+      "deviceInkPixels": 91619
+    },
+    "2": {
+      "inkAreaRatio": 0.812510134200662,
+      "iouSvgVsDevice": 0.8090849806981051,
+      "pdfDiffFrac": 0.09879434826016023,
+      "pdfMae": 23.002699856332335,
+      "ourInkPixels": 170372,
+      "deviceInkPixels": 209686
+    },
+    "3": {
+      "inkAreaRatio": 0.9721010527613793,
+      "iouSvgVsDevice": 0.8352434913576705,
+      "pdfDiffFrac": 0.06095070251053157,
+      "pdfMae": 12.993607625952711,
+      "ourInkPixels": 63067,
+      "deviceInkPixels": 64877
+    }
+  },
+  "sticker-n5-20260016-plugin-artwork": {
+    "1": {
+      "inkAreaRatio": 0.8646971935007386,
+      "iouSvgVsDevice": 0.8646971935007386,
+      "pdfDiffFrac": 0.0001959228515625,
+      "pdfMae": 0.022370402018229166,
+      "ourInkPixels": 2927,
+      "deviceInkPixels": 3385
+    },
+    "2": {
+      "inkAreaRatio": 0.9735057963301479,
+      "iouSvgVsDevice": 0.958010973621984,
+      "pdfDiffFrac": 0.008263142903645833,
+      "pdfMae": 2.0583591715494793,
+      "ourInkPixels": 42072,
+      "deviceInkPixels": 43217
+    },
+    "3": {
+      "inkAreaRatio": null,
+      "iouSvgVsDevice": 1,
+      "pdfDiffFrac": 0.0007000732421875,
+      "pdfMae": 0.16409566243489584,
+      "ourInkPixels": 0,
+      "deviceInkPixels": 0
+    }
+  },
+  "stroke-n5-20260016-isolation-tools-colors-widths": {
+    "1": {
+      "inkAreaRatio": 1.0038015930485156,
+      "iouSvgVsDevice": 0.882803197822759,
+      "pdfDiffFrac": 0.0003279622395833333,
+      "pdfMae": 0.03553120930989583,
+      "ourInkPixels": 5545,
+      "deviceInkPixels": 5524
+    },
+    "2": {
+      "inkAreaRatio": 0.950322637673473,
+      "iouSvgVsDevice": 0.9451644185841488,
+      "pdfDiffFrac": 0.011904703776041666,
+      "pdfMae": 2.8915777587890625,
+      "ourInkPixels": 53755,
+      "deviceInkPixels": 56565
+    },
+    "3": {
+      "inkAreaRatio": 0.8615489394823895,
+      "iouSvgVsDevice": 0.8414821944177093,
+      "pdfDiffFrac": 0.0036875406901041665,
+      "pdfMae": 0.5994478352864583,
+      "ourInkPixels": 8855,
+      "deviceInkPixels": 10278
+    },
+    "4": {
+      "inkAreaRatio": 1.0015573214071796,
+      "iouSvgVsDevice": 0.9179261526688349,
+      "pdfDiffFrac": 0.00599609375,
+      "pdfMae": 1.4131459554036458,
+      "ourInkPixels": 25082,
+      "deviceInkPixels": 25043
+    },
+    "5": {
+      "inkAreaRatio": 0.9739219565683774,
+      "iouSvgVsDevice": 0.9696025497704731,
+      "pdfDiffFrac": 0.009366048177083334,
+      "pdfMae": 2.330916341145833,
+      "ourInkPixels": 40857,
+      "deviceInkPixels": 41951
+    }
+  },
+  "test-a5x-20220011-old-pen-ids": {
+    "1": {
+      "inkAreaRatio": 0.8071450740807292,
+      "iouSvgVsDevice": 0.7533560504001902,
+      "pdfDiffFrac": 0.014259091849903816,
+      "pdfMae": 1.553194322692186,
+      "ourInkPixels": 49411,
+      "deviceInkPixels": 61217
+    },
+    "2": {
+      "inkAreaRatio": 1.052470100281242,
+      "iouSvgVsDevice": 0.8599304929849402,
+      "pdfDiffFrac": 0.07209103416368373,
+      "pdfMae": 9.77464608140356,
+      "ourInkPixels": 37048,
+      "deviceInkPixels": 35201
+    }
+  },
+  "turkish-a6x-20230015-handwriting-erase": {
+    "1": {
+      "inkAreaRatio": 0.8429862272112093,
+      "iouSvgVsDevice": 0.8403307066270508,
+      "pdfDiffFrac": 0.00868816507171208,
+      "pdfMae": 1.10158437735895,
+      "ourInkPixels": 84710,
+      "deviceInkPixels": 100488
+    }
+  }
+}


### PR DESCRIPTION
Closes #99 (follow-up to #95 / #98).

#98 added `toPdf({ vectorInk: true })` and a three-way fixture comparison site, but the only guard on the PDF path was operator-presence assertions (`m` shows up; SVG and PDF share the pipeline). Those pass even if the PDF renders the wrong picture, as long as it emits *some* path operators. This PR closes that gap with a CI suite that rasterises the library's vectorInk PDF against Supernote's own device PDF export per fixture page and fails on *drift* beyond committed baselines.

## The three metrics (per fixture page, vs the device's own PDF as ground truth)

| Metric | What | Catches |
|---|---|---|
| `inkAreaRatio` | dark-ink pixel ratio of our SVG over the device's | whole-stroke-missing, width doubling |
| `iouSvgVsDevice` | IoU of the two ink masks (spatial) | hatched fill over nearby ink, extra/missing contours on partial erases — ink in the wrong *place* |
| `pdfDiffFrac` | full-page pixel disagreement between our **vectorInk PDF** and the device PDF (threshold 40 grey levels so the shared template cancels) | the only one that rasterises the actual library PDF (sees pdf-lib's drawing) and the only one that sees *colour* — catches white-ink cover-ups the dark-ink masks are blind to |

Baselines are **measurements of the known-good render, not targets** — CI fails on drift, the way `--update` snapshots work. Regenerate after an intentional rendering change: `npm run visual-diff:baseline`.

## Design decisions validated by spiking (not assumed)

- The planned 64×64 thumbnail was **dropped** — spiking on the densest page (`turkish-…-handwriting-erase` p1) showed it's dominated by the shared page template, so a single-line regression moved it only ~0.006, *inside* the planned ±0.02 band. Replaced by the three metrics above at native resolution.
- A template-subtraction ink-mask idea was **dropped** — `toImage`'s template is RGBA with transparency, so it doesn't cancel cleanly against the RGB PDF render.
- resvg renders the full-page vectorInk SVG (base64 `<image>` + paths) correctly — confirmed before building on it.
- Downsampling was **reverted** (the suite's cost is rendering, not pixel math); page tests are `test.concurrent` instead.

## Verification

```bash
npm run build      # pass
npm run lint       # pass
npx tsc -p tsconfig.scripts.json   # pass (type-checks scripts)
npm run build:site # pass
npm test           # 228 tests pass (189 existing + 39 new), ~152s wall
```

A simulated regression (2× ink on `ink-a5x` p1; IoU 0.95 vs the real 0.84 on `turkish` p1) fails the suite with a message naming the drifted metric and the regenerate command.

## Files

- `scripts/visual-diff.ts` — metric engine + tolerance logic
- `scripts/generate-visual-diff-baselines.ts` — `npm run visual-diff:baseline`
- `tests/pdf-visual-diff.test.ts` — 39 concurrent tests
- `tests/visual-diff-baselines.json` — committed baselines (16 fixtures, 37 pages)
- `plans/visual-diff-vector-ink-pdf.md` — design + implementation notes
- `package.json` — devDep `@resvg/resvg-js`, `visual-diff:baseline` script
- `.github/workflows/test.yml` — pin `poppler-utils` (provides `pdftoppm`)
- `AGENTS.md` — table row + `vectorInk visual-diff suite` section

The new suite adds ~30s wall to CI (overlaps the other files via the 2-worker pool). Full rationale and the resolved open questions are in `plans/visual-diff-vector-ink-pdf.md`.