### PR TITLE
Fix recognized-text position for N6/A6X (recognition canvas != 1920)

### DIFF
--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -30,27 +30,77 @@ import {
 } from './vector-ink.js';
 
 // Recognized word bounding boxes are stored in raster-pixel units divided by
-// a scale factor that is *not* a universal constant: 11.9 (confirmed per
-// plans/rtr-searchable-pdf.md) only holds at the 1920px-wide reference page
-// Manta-family devices (SupernoteX's `header.APPLY_EQUIPMENT === 'N5'`
-// check) render at. Every other device family - including the far more
-// common A5X, whose default pageWidth is 1404 - needs that reference scale
-// shrunk proportionally to its own actual page width, or recognized-word
-// positions drift further from the real ink the further down the page a
-// word sits (the error is multiplicative, so it's barely visible on the
-// first line and lands on blank paper several lines down). Confirmed
-// against a real A5X note fixture in
-// https://github.com/philips/supernote-obsidian-plugin/pull/206.
+// a scale factor that is *not* a universal constant - it depends on which
+// device family produced the note.
+//
+// The recognition engine renders each page to a fixed-width "reference
+// canvas" before recognizing, and stores bounding boxes in that canvas's
+// pixel space divided by 11.9 (confirmed per plans/rtr-searchable-pdf.md).
+// So the universal part is: canvas_pixel = recognition_unit * 11.9. What is
+// *not* universal is the reference canvas width, which is a FIXED
+// per-device constant (it does NOT scale with an upscaled render):
+//
+//   - Manta (N5, pageWidth 1920): canvas 1920  → scale = render * 11.9 / 1920
+//   - A5X       (pageWidth 1404): canvas 1920  → scale = render * 11.9 / 1920
+//     (A5X is the only known device whose recognition canvas, 1920,
+//      differs from its own pageWidth, 1404 - it upsamples recognition to
+//      the same 1920 canvas Manta uses. philips/supernote-obsidian-plugin#204:
+//      a fixed 11.9 landed A5X highlights a full page-height below the ink.)
+//   - Nomad (N6, pageWidth 1404): canvas 1404  → scale = render * 11.9 / 1404
+//   - A6X   (pageWidth 1404):      canvas 1404  → scale = render * 11.9 / 1404
+//     (N6/A6X render recognition natively at their own pageWidth, so the
+//      correct scale at native resolution is the raw 11.9, NOT shrunk by
+//      1404/1920. philips/supernote-obsidian-plugin#219: the old code applied
+//      that 1920-reference shrink to every non-Manta family, which is right
+//      for A5X but wrong for N6/A6X - it pulled their boxes to ~8.70 when they
+//      line up at the raw 11.9.)
+//
+// I.e. #204's "recognition coordinates are defined against a fixed 1920-unit
+// canvas" model was over-generalized from a single A5X fixture: 1920 is the
+// canvas for Manta AND A5X, but N6/A6X use their own pageWidth (1404) as the
+// canvas. (A pre-X A5, if one exists, may also upsample to 1920 the way A5X
+// does - we have no fixture to confirm; only A5X is special-cased here,
+// deliberately, because it's the only one the data covers.)
+//
+// `renderWidth` is the width of the raster being rendered into (the image's
+// pixel width - `upscale` grows it beyond `note.pageWidth`). `equipment` is
+// `header.APPLY_EQUIPMENT` (e.g. 'A5X', 'N5', 'N6', 'A6X'). `nativePageWidth`
+// is the note's own `pageWidth` (the device's native, pre-upscale page width) -
+// needed to pick the canvas for non-A5X devices, since `renderWidth` alone
+// can't recover it when `upscale > 1`.
+//
+// When `equipment` is omitted (undefined), the legacy 1920-reference-canvas
+// behavior is preserved so existing direct callers of addPdfPage()/addSvgPage()
+// that don't pass it keep their pre-#219 output unchanged; the high-level
+// toPdf()/toSvg() always pass the note's real equipment and nativePageWidth.
 const RECOGNITION_REFERENCE_PAGE_WIDTH = 1920;
 const RECOGNITION_REFERENCE_SCALE = 11.9;
 
-/** Scale factor to convert a recognized word's native bounding-box units
- * into raster-pixel units, for a page whose actual pixel width is
- * `pageWidth`. Exported so other exporters positioning an invisible text
- * overlay over the same recognition data (e.g. svg.ts) share this instead
- * of re-deriving it. */
-export function recognitionCoordinateScale(pageWidth: number): number {
-	return (pageWidth * RECOGNITION_REFERENCE_SCALE) / RECOGNITION_REFERENCE_PAGE_WIDTH;
+/** Scale factor to convert a recognized word's native bounding-box units into
+ * raster-pixel units at the given `renderWidth`, for a note produced by
+ * `equipment` (`header.APPLY_EQUIPMENT`, e.g. 'A5X', 'N5', 'N6', 'A6X') whose
+ * native page width is `nativePageWidth` (the note's `pageWidth`, NOT the
+ * possibly-upscaled render width). Pass the real equipment + nativePageWidth
+ * for correct results on every device family and at every upscale factor;
+ * omitting both keeps the legacy 1920-reference-canvas behavior (correct only
+ * for A5X and Manta, wrong for N6/A6X - see the comment above).
+ *
+ * Exported so other exporters positioning an invisible text overlay over
+ * the same recognition data (e.g. svg.ts, and the obsidian plugin's own
+ * wordOverlay.ts) share this instead of re-deriving it. */
+export function recognitionCoordinateScale(
+	renderWidth: number,
+	equipment?: string,
+	nativePageWidth?: number,
+): number {
+	// A5X is the only known device whose recognition canvas (1920) differs
+	// from its own pageWidth. For every other device the canvas equals its
+	// native pageWidth. Omitting equipment keeps the legacy 1920 canvas so
+	// direct callers that don't pass it get unchanged pre-#219 output.
+	const canvasWidth = equipment === undefined || equipment === 'A5X'
+		? RECOGNITION_REFERENCE_PAGE_WIDTH
+		: (nativePageWidth ?? renderWidth);
+	return (renderWidth * RECOGNITION_REFERENCE_SCALE) / canvasWidth;
 }
 
 export interface ToPdfOptions {
@@ -113,6 +163,20 @@ export interface AddPdfPageOptions {
 	strokes?: IStroke[];
 	/** How to render each of `strokes`, aligned by index -- see `StrokeStyle`. */
 	strokeStyles?: StrokeStyle[];
+	/** Device family this page's note was produced by
+	 * (`header.APPLY_EQUIPMENT`, e.g. 'A5X', 'N5', 'N6', 'A6X'), used to pick
+	 * the correct recognition-coordinate scale - see
+	 * `recognitionCoordinateScale`. Omitting it (with `nativePageWidth`)
+	 * keeps the legacy 1920-reference-canvas behavior (correct only for A5X
+	 * and Manta, wrong for N6/A6X); `toPdf()` always passes the note's real
+	 * equipment. */
+	equipment?: string;
+	/** The note's own `pageWidth` (the device's native, pre-upscale page
+	 * width) - needed to pick the recognition canvas for non-A5X devices
+	 * when `image` is upscaled beyond it. Defaults to `image`'s width (i.e.
+	 * no upscale), which is correct for non-upscaled renders.
+	 * `toPdf()` always passes `note.pageWidth`. */
+	nativePageWidth?: number;
 }
 
 // Draws the recognized handwriting (RTR) text invisibly onto `pdfPage` at
@@ -125,11 +189,13 @@ function drawRecognitionText(
 	fontKey: PDFName,
 	font: PDFFont,
 	page: IPdfPage,
-	pageWidth: number,
+	renderWidth: number,
 	pointsPerPixel: number,
 	heightPts: number,
+	equipment?: string,
+	nativePageWidth?: number,
 ): void {
-	const scale = recognitionCoordinateScale(pageWidth);
+	const scale = recognitionCoordinateScale(renderWidth, equipment, nativePageWidth);
 	for (const element of page.recognitionElements) {
 		if (element.type !== 'Text') continue;
 
@@ -331,7 +397,7 @@ export async function addPdfPage(
 	image: Image | Uint8Array,
 	options: AddPdfPageOptions = {},
 ): Promise<void> {
-	const { dpi = 300, strokes, strokeStyles } = options;
+	const { dpi = 300, strokes, strokeStyles, equipment, nativePageWidth } = options;
 	const { pdfDoc, font } = ctx;
 	const pointsPerPixel = 72 / dpi;
 
@@ -350,7 +416,7 @@ export async function addPdfPage(
 		drawVectorInkPrimitives(pdfPage, buildVectorInkPrimitives(strokes, strokeStyles), heightPts, pointsPerPixel);
 	}
 
-	drawRecognitionText(pdfPage, fontKey, font, page, pngImage.width, pointsPerPixel, heightPts);
+	drawRecognitionText(pdfPage, fontKey, font, page, pngImage.width, pointsPerPixel, heightPts, equipment, nativePageWidth);
 }
 
 /**
@@ -373,7 +439,7 @@ export async function addTextOnlyPdfPage(
 	pageHeight: number,
 	options: AddPdfPageOptions = {},
 ): Promise<void> {
-	const { dpi = 300 } = options;
+	const { dpi = 300, equipment, nativePageWidth } = options;
 	const { pdfDoc, font } = ctx;
 	const pointsPerPixel = 72 / dpi;
 
@@ -383,7 +449,7 @@ export async function addTextOnlyPdfPage(
 	const pdfPage = pdfDoc.addPage([widthPts, heightPts]);
 	const fontKey = pdfPage.node.newFontDictionary(font.name, font.ref);
 
-	drawRecognitionText(pdfPage, fontKey, font, page, pageWidth, pointsPerPixel, heightPts);
+	drawRecognitionText(pdfPage, fontKey, font, page, pageWidth, pointsPerPixel, heightPts, equipment, nativePageWidth ?? pageWidth);
 }
 
 /**
@@ -421,6 +487,8 @@ export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promi
 			dpi,
 			strokes: vip?.useVectorInk ? vip.strokes : undefined,
 			strokeStyles: vip?.useVectorInk ? vip.styles : undefined,
+			equipment: note.header.APPLY_EQUIPMENT,
+			nativePageWidth: note.pageWidth,
 		});
 	}
 

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -54,8 +54,8 @@ function escapeXml(text: string): string {
  * own `textLength`/`lengthAdjust` attributes do the stretch-to-fit-the-box
  * scaling natively instead of needing a manually computed horizontal-scale
  * percentage. */
-function buildRecognitionTextElements(page: IPdfPage, pageWidth: number): string {
-	const scale = recognitionCoordinateScale(pageWidth);
+function buildRecognitionTextElements(page: IPdfPage, renderWidth: number, equipment?: string, nativePageWidth?: number): string {
+	const scale = recognitionCoordinateScale(renderWidth, equipment, nativePageWidth);
 	const elements: string[] = [];
 	for (const element of page.recognitionElements) {
 		if (element.type !== 'Text') continue;
@@ -166,6 +166,20 @@ export interface AddSvgPageOptions {
 	 * straight from its stroke's own already-upscaled points, so it needs no
 	 * separate scaling). */
 	strokeStyles?: StrokeStyle[];
+	/** Device family this page's note was produced by
+	 * (`header.APPLY_EQUIPMENT`, e.g. 'A5X', 'N5', 'N6', 'A6X'), used to pick
+	 * the correct recognition-coordinate scale - see
+	 * `recognitionCoordinateScale`. Omitting it (with `nativePageWidth`)
+	 * keeps the legacy 1920-reference-canvas behavior (correct only for A5X
+	 * and Manta, wrong for N6/A6X); `toSvg()` always passes the note's real
+	 * equipment. */
+	equipment?: string;
+	/** The note's own `pageWidth` (the device's native, pre-upscale page
+	 * width) - needed to pick the recognition canvas for non-A5X devices
+	 * when the embedded `image` is upscaled beyond it. Defaults to `pageWidth`
+	 * (i.e. no upscale), which is correct for non-upscaled renders.
+	 * `toSvg()` always passes `note.pageWidth`. */
+	nativePageWidth?: number;
 }
 
 /**
@@ -189,7 +203,7 @@ export function addSvgPage(
 	pageHeight: number,
 	options: AddSvgPageOptions = {},
 ): string {
-	const { dpi, includeText = true, strokes, strokeStyles } = options;
+	const { dpi, includeText = true, strokes, strokeStyles, equipment, nativePageWidth } = options;
 
 	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
 	const base64 = encodeBase64(pngBytes);
@@ -197,7 +211,7 @@ export function addSvgPage(
 	const widthAttr = dpi ? `${pageWidth / dpi}in` : `${pageWidth}`;
 	const heightAttr = dpi ? `${pageHeight / dpi}in` : `${pageHeight}`;
 
-	const textElements = includeText ? buildRecognitionTextElements(page, pageWidth) : '';
+	const textElements = includeText ? buildRecognitionTextElements(page, pageWidth, equipment, nativePageWidth ?? pageWidth) : '';
 	const { defs, elements: strokeElements } =
 		strokes && strokes.length ? buildSvgElements(buildVectorInkPrimitives(strokes, strokeStyles)) : { defs: '', elements: '' };
 
@@ -286,6 +300,8 @@ export async function toSvg(note: ISupernote, options: ToSvgOptions = {}): Promi
 			includeText,
 			strokes,
 			strokeStyles,
+			equipment: note.header.APPLY_EQUIPMENT,
+			nativePageWidth: note.pageWidth,
 		});
 	});
 }

--- a/tests/pdf.test.ts
+++ b/tests/pdf.test.ts
@@ -163,14 +163,41 @@ describe("pdf", () => {
     }
   })
 
-  test("recognitionCoordinateScale scales proportionally to pageWidth, not a fixed 11.9, for non-Manta devices", () => {
-    // 11.9 only holds at the 1920px-wide reference page (Manta-family
-    // devices); every narrower page (e.g. A5X's default 1404) needs it
-    // scaled down proportionally, or recognized-word positions drift
-    // further from the actual ink the further down the page a word sits.
-    // See https://github.com/philips/supernote-obsidian-plugin/pull/206.
-    expect(recognitionCoordinateScale(1920)).toBeCloseTo(11.9)
+  test("recognitionCoordinateScale is device-family-aware: A5X uses the 1920 reference canvas, every other family uses its own native pageWidth", () => {
+    // The recognition canvas is a FIXED per-device constant (it does NOT
+    // scale with an upscaled render): 1920 for Manta (N5) AND A5X, and the
+    // device's own native pageWidth for N6/A6X (1404). So the scale is
+    // renderWidth * 11.9 / canvasWidth.
+    //
+    // - A5X (native 1404) is the only known device whose canvas (1920)
+    //   differs from its pageWidth: scale = render * 11.9 / 1920, so at
+    //   native resolution 1404*11.9/1920 ≈ 8.70 (philips/supernote-obsidian-plugin#204
+    //   - a fixed 11.9 landed highlights a full page below the ink).
+    // - N6/A6X (native 1404) render recognition natively at 1404, so the
+    //   correct scale at native resolution is the raw 11.9, NOT shrunk by
+    //   1404/1920 (philips/supernote-obsidian-plugin#219 - the old shrink pulled
+    //   their boxes to ~8.70 when they line up at 11.9).
+    // - N5/Manta (native 1920): 11.9 at native resolution.
+    //
+    // nativePageWidth (3rd arg) only matters when renderWidth differs from
+    // the native pageWidth (i.e. upscale > 1): then it's needed to recover
+    // the canvas for non-A5X devices, since renderWidth alone can't.
+    expect(recognitionCoordinateScale(1920, 'N5', 1920)).toBeCloseTo(11.9)
+    expect(recognitionCoordinateScale(1404, 'A5X', 1404)).toBeCloseTo((1404 * 11.9) / 1920)
+    // N6 and A6X: canvas == native pageWidth, so the raw 11.9 at native res:
+    expect(recognitionCoordinateScale(1404, 'N6', 1404)).toBeCloseTo(11.9)
+    expect(recognitionCoordinateScale(1404, 'A6X', 1404)).toBeCloseTo(11.9)
+    // Upscale grows the scale (canvas is fixed, renderWidth doubles):
+    expect(recognitionCoordinateScale(1920 * 2, 'N5', 1920)).toBeCloseTo(11.9 * 2)
+    expect(recognitionCoordinateScale(1404 * 2, 'N6', 1404)).toBeCloseTo(11.9 * 2)
+    expect(recognitionCoordinateScale(1404 * 2, 'A5X', 1404)).toBeCloseTo((1404 * 2 * 11.9) / 1920)
+    // nativePageWidth defaults to renderWidth (i.e. no upscale) when omitted:
+    expect(recognitionCoordinateScale(1404, 'N6')).toBeCloseTo(11.9)
+    // Omitting equipment keeps the legacy 1920-reference-canvas behavior so
+    // direct addPdfPage()/addSvgPage() callers that don't pass it get
+    // unchanged pre-#219 output (correct only for A5X/Manta):
     expect(recognitionCoordinateScale(1404)).toBeCloseTo((1404 * 11.9) / 1920)
+    expect(recognitionCoordinateScale(1920)).toBeCloseTo(11.9)
   })
 
   test("toPdf({ vectorInk: true }) renders the searchable text layer unchanged", { timeout: 30000 }, async () => {

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -286,14 +286,21 @@ describe("svg", () => {
     expect(svgs.join("")).not.toContain("<text ")
   })
 
-  // One fixture per device family whose native `pageWidth` differs (Manta's
-  // reference 1920 vs. every other family's 1404 default - see
-  // recognitionCoordinateScale()'s own comment in pdf.ts), each with a known
-  // word's raw bounding-box pulled directly from the note's own
-  // recognitionElements, so the expected SVG position is derived from that
-  // note's real data rather than a value copied out of the implementation.
+  // One fixture per device family, each with a known word's raw bounding-box
+  // pulled directly from the note's own recognitionElements, so the expected
+  // SVG position is derived from that note's real data rather than a value
+  // copied out of the implementation. Covers the three recognition-canvas
+  // regimes (see recognitionCoordinateScale()'s own comment in pdf.ts):
+  //   - Manta (N5): canvas == pageWidth == 1920 → raw 11.9
+  //   - A5X:        canvas 1920, pageWidth 1404  → 11.9 * 1404/1920 ≈ 8.70
+  //   - N6/A6X:     canvas == pageWidth == 1404 → raw 11.9 (NOT shrunk)
+  // The N6/A6X case is the fix for philips/supernote-obsidian-plugin#219:
+  // the old code shrunk every non-Manta family by pageWidth/1920, which is
+  // correct for A5X but wrong for N6/A6X (it pulled their boxes to ~8.70
+  // when they line up at the raw 11.9).
   const deviceFixtures: {
     device: string;
+    equipment: string;
     file: string;
     pageWidth: number;
     word: string;
@@ -301,6 +308,7 @@ describe("svg", () => {
   }[] = [
     {
       device: "Manta",
+      equipment: "N5",
       file: "rtr-n5-20230015-recognition.note",
       pageWidth: 1920,
       word: "Real",
@@ -308,13 +316,23 @@ describe("svg", () => {
     },
     {
       device: "A5X",
+      equipment: "A5X",
       file: "ink-a5x-2.14.28-old-pen-width.note",
       pageWidth: 1404,
       word: "Subject",
       box: { x: 12.776001, y: 13.224001, width: 25.072002, height: 9.84 },
     },
     {
-      device: "Nomad",
+      device: "Nomad (N6)",
+      equipment: "N6",
+      file: "link-n6-3.26.40-partial-erase-3p.note",
+      pageWidth: 1404,
+      word: "INK",
+      box: { x: 4.6615, y: 12.097501, width: 22.956001, height: 7.0700006 },
+    },
+    {
+      device: "A6X",
+      equipment: "A6X",
       file: "blank-a6x-3.15.27-shapes-rtr.note",
       pageWidth: 1404,
       word: "Square",
@@ -323,11 +341,12 @@ describe("svg", () => {
   ]
 
   test.each(deviceFixtures)(
-    "$device (pageWidth $pageWidth): positions recognized text via recognitionCoordinateScale(pageWidth), not a fixed 11.9",
+    "$device (pageWidth $pageWidth, equipment $equipment): positions recognized text via the device-correct recognitionCoordinateScale",
     { timeout: 30000 },
-    async ({ file, pageWidth, word, box }) => {
+    async ({ equipment, file, pageWidth, word, box }) => {
       const sn = new SupernoteX(await readFileToUint8Array(file))
       expect(sn.pageWidth).toBe(pageWidth)
+      expect(sn.header.APPLY_EQUIPMENT).toBe(equipment)
 
       const [svg] = await toSvg(sn, { pageNumbers: [1] })
       await fs.writeFile(`tests/output/${file}.0.svg`, svg)
@@ -336,14 +355,25 @@ describe("svg", () => {
       expect(match).not.toBeNull()
       const actualY = Number(match![1])
 
-      // addSvgPage positions the baseline at (box.y + box.height) * scale.
-      const scale = recognitionCoordinateScale(pageWidth)
+      // addSvgPage positions the baseline at (box.y + box.height) * scale,
+      // where scale is the device-correct recognitionCoordinateScale at the
+      // render width (native here, since toSvg's default upscale is 1).
+      const scale = recognitionCoordinateScale(pageWidth, equipment, pageWidth)
       const expectedY = (box.y + box.height) * scale
-      const wrongY = (box.y + box.height) * 11.9 // what the old fixed-11.9 bug (philips/supernote-obsidian-plugin#206) would have produced
+      // What the pre-#219 bug would have produced for the N6/A6X fixtures:
+      // the legacy 1920-reference-canvas shrink (correct only for A5X).
+      const legacyY = (box.y + box.height) * recognitionCoordinateScale(pageWidth)
 
       expect(actualY).toBeCloseTo(expectedY, 1)
-      if (pageWidth !== 1920) {
-        expect(Math.abs(actualY - wrongY)).toBeGreaterThan(20)
+      if (equipment === 'N6' || equipment === 'A6X') {
+        // The fix moves N6/A6X from the legacy ~8.70 scale to the raw 11.9 -
+        // a difference of >20px on a word this far down the page.
+        expect(Math.abs(actualY - legacyY)).toBeGreaterThan(20)
+      }
+      if (equipment === 'A5X') {
+        // A5X is the family the legacy 1920-reference-canvas behavior was
+        // made for, so the fix must not move it.
+        expect(Math.abs(actualY - legacyY)).toBeLessThan(0.5)
       }
     },
   )


### PR DESCRIPTION
## Problem

`recognitionCoordinateScale` assumed **every** device's recognition coordinates are defined against a fixed 1920px-wide canvas, so it scaled all of them by `pageWidth/1920`. That was derived from a single A5X fixture and over-generalized. 1920 is the recognition canvas for **Manta (N5) and A5X**, but **Nomad (N6) and A6X** render recognition natively at their own `pageWidth` (1404), so the correct scale for them at native resolution is the **raw 11.9** — the `pageWidth/1920` shrink pulled their boxes to ~8.70, drifting recognized-word highlights off the ink the further down the page a word sat.

Reported in philips/supernote-obsidian-plugin#219 (the on-screen `word-overlay-span`s lined up on A5X/N5 files but drifted off the ink on N6 files). The PDF/SVG export invisible-text layers from `toPdf()`/`toSvg()`/`addPdfPage()`/`addSvgPage()` have the same bug.

## How I confirmed it

Rendered every recognition-bearing fixture and measured ink density inside the recognition boxes across a scale sweep:

| file | equip | pageWidth | best scale | 8.70 (old) | 11.9 (new) |
|---|---|---|---|---|---|
| ink-a5x… | A5X | 1404 | **8.70** | 0.158 ✓ | 0.031 |
| rtr-n5… | N5 | 1920 | 11.9 | — | 0.096 ✓ |
| link-n6… | N6 | 1404 | **11.9** | 0.025 | 0.088 ✓ |
| render-n6-moonchild | N6 | 1404 | **11.9** | low | high ✓ |
| color-n6… | N6 | 1404 | **11.9** | 0.024 | 0.095 ✓ |
| turkish-a6x… | A6X | 1404 | **11.9** | 0.061 | 0.155 ✓ |

A5X peaks at ~8.70; N5/N6/A6X all peak at 11.9.

## The fix

The recognition canvas is a **fixed per-device constant** (it does NOT scale with an upscaled render), so the correct formula is:

```
scale = renderWidth * 11.9 / canvasWidth
```

where `canvasWidth = 1920` for `{N5, A5X}` and `= the device's native pageWidth` for `{N6, A6X}`. A5X is the only known device whose recognition canvas (1920) differs from its own `pageWidth` (1404).

`recognitionCoordinateScale` now takes `(renderWidth, equipment?, nativePageWidth?)`:
- `equipment` is `header.APPLY_EQUIPMENT` (e.g. `A5X`, `N5`, `N6`, `A6X`) — picks the canvas.
- `nativePageWidth` is the note's own `pageWidth` (needed to recover the canvas for N6/A6X when `upscale > 1`, since `renderWidth` alone can't).
- Omitting both keeps the legacy 1920-reference-canvas behavior so existing direct callers of `addPdfPage()`/`addSvgPage()` get unchanged pre-#219 output (correct only for A5X/Manta).

`toPdf()`/`toSvg()` now pass the note's real `equipment` and `nativePageWidth`, so the high-level export APIs are correct on every device family and at every upscale factor. The low-level `addPdfPage()`/`addTextOnlyPdfPage()`/`addSvgPage()` gain optional `equipment` + `nativePageWidth` on their options interfaces.

## Tests

- `tests/pdf.test.ts`: `recognitionCoordinateScale` test rewritten to cover all four device families at native resolution **and** at `upscale: 2` (canvas is fixed, so the scale must double), plus the legacy-default (no equipment) behavior.
- `tests/svg.test.ts`: the device-fixture parametrized test now covers N6 (`link-n6-…`, word `INK`) and A6X (`blank-a6x-…`, word `Square`) in addition to Manta and A5X, asserting each lands at the device-correct scale and (for N6/A6X) that the fix moves it >20px away from the legacy 1920-shrink position. The old A6X \"Nomad\" case was tautological — it asserted the implementation against itself at 8.70, not against the actual ink; the ink-density sweep shows A6X wants 11.9.

`npm test` (190/190), `npm run lint`, `npm run build` all clean.

## Follow-up (not in this PR)

The obsidian plugin's PDF/SVG export workers (`pdfBuild.worker.ts`, `rasterize.worker.ts`) call `addPdfPage()`/`addSvgPage()` directly with `IPdfPage` slices and don't yet thread `equipment`/`nativePageWidth` through their worker messages, so their output stays on the legacy (wrong-for-N6/A6X) scale until a separate plugin change passes those through. The plugin's on-screen `wordOverlay.ts` has a sibling copy of this scale logic that was fixed separately in the same issue.