### PR TITLE
fix: layer raster text over vector ink

### DIFF
--- a/scripts/build-fixture-site.ts
+++ b/scripts/build-fixture-site.ts
@@ -16,6 +16,7 @@ import * as path from 'node:path';
 import { SupernoteX } from '../src/parsing.js';
 import { toSvg } from '../src/svg.js';
 import { toPdf } from '../src/pdf.js';
+import { parseDisabledInkRects, RasterInkRect } from '../src/vector-ink.js';
 import { extractPageForms, pdfPageToSvg, devicePageToSvgDocument } from './pdf-vector.js';
 
 const INPUT_DIR = 'tests/input';
@@ -173,9 +174,13 @@ function svgInkArea(svg: string): number {
 	return total;
 }
 
-/** Our SVG with the background raster removed, so both sides show ink only. */
-function inkOnly(svg: string): string {
-	return svg.replace(/<image\b[^>]*\/>/g, '');
+/** Our SVG with its normal background raster removed, while retaining the
+ * clipped bitmap-only objects that vector ink cannot represent as paths. */
+function inkOnly(svg: string, rasterInkRects: RasterInkRect[] = []): string {
+	if (rasterInkRects.length === 0) return svg.replace(/<image\b[^>]*\/>/g, '');
+	const clipId = 'raster-ink-regions';
+	const clip = `<defs><clipPath id="${clipId}" clipPathUnits="userSpaceOnUse">${rasterInkRects.map((r) => `<rect x="${r.x}" y="${r.y}" width="${r.width}" height="${r.height}"/>`).join('')}</clipPath></defs>`;
+	return svg.replace(/<image\b([^>]*)\/>/g, `${clip}<image clip-path="url(#${clipId})"$1/>`);
 }
 
 interface PageComparison {
@@ -224,7 +229,7 @@ async function buildFixture(noteFile: string): Promise<FixtureComparison | null>
 	for (let i = 0; i < Math.min(forms.length, ours.length); i++) {
 		const pageNumber = i + 1;
 		const device = pdfPageToSvg(forms[i], note.pageHeight);
-		const oursSvg = inkOnly(ours[i]);
+		const oursSvg = inkOnly(ours[i], parseDisabledInkRects(note.pages[i].DISABLE));
 		const libraryPdf = await toPdf(note, { vectorInk: true, pageNumbers: [pageNumber] });
 		pages.push({
 			pageNumber,


### PR DESCRIPTION
## Summary
- split vector-ink pages into a template/background image and a transparent bitmap-only text-box/Digest overlay
- paint that overlay after vector paths in SVG and PDF, preserving text over highlighter strokes
- keep the overlay in fixture-site ink-only SVG comparisons without leaking the template beneath it

## Validation
- `npm test`
- `npm run build:site`