### PR TITLE
fix: layer raster text over vector ink

### DIFF
--- a/scripts/build-fixture-site.ts
+++ b/scripts/build-fixture-site.ts
@@ -16,7 +16,6 @@ import * as path from 'node:path';
 import { SupernoteX } from '../src/parsing.js';
 import { toSvg } from '../src/svg.js';
 import { toPdf } from '../src/pdf.js';
-import { parseDisabledInkRects, RasterInkRect } from '../src/vector-ink.js';
 import { extractPageForms, pdfPageToSvg, devicePageToSvgDocument } from './pdf-vector.js';
 
 const INPUT_DIR = 'tests/input';
@@ -174,13 +173,11 @@ function svgInkArea(svg: string): number {
 	return total;
 }
 
-/** Our SVG with its normal background raster removed, while retaining the
- * clipped bitmap-only objects that vector ink cannot represent as paths. */
-function inkOnly(svg: string, rasterInkRects: RasterInkRect[] = []): string {
-	if (rasterInkRects.length === 0) return svg.replace(/<image\b[^>]*\/>/g, '');
-	const clipId = 'raster-ink-regions';
-	const clip = `<defs><clipPath id="${clipId}" clipPathUnits="userSpaceOnUse">${rasterInkRects.map((r) => `<rect x="${r.x}" y="${r.y}" width="${r.width}" height="${r.height}"/>`).join('')}</clipPath></defs>`;
-	return svg.replace(/<image\b([^>]*)\/>/g, `${clip}<image clip-path="url(#${clipId})"$1/>`);
+/** Our SVG with the normal template/background raster removed. Bitmap-only
+ * text-box/Digest ink is emitted as a separately marked image after vectors,
+ * so it remains in this ink-only comparison. */
+function inkOnly(svg: string): string {
+	return svg.replace(/<image data-page-background="true"[^>]*\/>/g, '');
 }
 
 interface PageComparison {
@@ -229,7 +226,7 @@ async function buildFixture(noteFile: string): Promise<FixtureComparison | null>
 	for (let i = 0; i < Math.min(forms.length, ours.length); i++) {
 		const pageNumber = i + 1;
 		const device = pdfPageToSvg(forms[i], note.pageHeight);
-		const oursSvg = inkOnly(ours[i], parseDisabledInkRects(note.pages[i].DISABLE));
+		const oursSvg = inkOnly(ours[i]);
 		const libraryPdf = await toPdf(note, { vectorInk: true, pageNumbers: [pageNumber] });
 		pages.push({
 			pageNumber,

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -26,7 +26,9 @@ import {
 	VectorInkPrimitive,
 	buildVectorInkPrimitives,
 	prepareVectorInkPages,
-	buildRenderNoteForVectorInk,
+	buildVectorInkBackgroundNote,
+	buildRasterInkOverlayNote,
+	parseDisabledInkRects,
 } from './vector-ink.js';
 
 // Recognized word bounding boxes are stored in raster-pixel units divided by
@@ -163,6 +165,8 @@ export interface AddPdfPageOptions {
 	strokes?: IStroke[];
 	/** How to render each of `strokes`, aligned by index -- see `StrokeStyle`. */
 	strokeStyles?: StrokeStyle[];
+	/** A transparent bitmap-only ink overlay painted after vector strokes. */
+	overlayImage?: Image | Uint8Array;
 	/** Device family this page's note was produced by
 	 * (`header.APPLY_EQUIPMENT`, e.g. 'A5X', 'N5', 'N6', 'A6X'), used to pick
 	 * the correct recognition-coordinate scale - see
@@ -397,12 +401,15 @@ export async function addPdfPage(
 	image: Image | Uint8Array,
 	options: AddPdfPageOptions = {},
 ): Promise<void> {
-	const { dpi = 300, strokes, strokeStyles, equipment, nativePageWidth } = options;
+	const { dpi = 300, strokes, strokeStyles, overlayImage, equipment, nativePageWidth } = options;
 	const { pdfDoc, font } = ctx;
 	const pointsPerPixel = 72 / dpi;
 
 	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
 	const pngImage = await pdfDoc.embedPng(pngBytes);
+	const overlayPng = overlayImage
+		? await pdfDoc.embedPng(overlayImage instanceof Uint8Array ? overlayImage : encodePng(overlayImage))
+		: undefined;
 
 	const widthPts = pngImage.width * pointsPerPixel;
 	const heightPts = pngImage.height * pointsPerPixel;
@@ -414,6 +421,9 @@ export async function addPdfPage(
 
 	if (strokes && strokes.length) {
 		drawVectorInkPrimitives(pdfPage, buildVectorInkPrimitives(strokes, strokeStyles), heightPts, pointsPerPixel);
+	}
+	if (overlayPng) {
+		pdfPage.drawImage(overlayPng, { x: 0, y: 0, width: widthPts, height: heightPts });
 	}
 
 	drawRecognitionText(pdfPage, fontKey, font, page, pngImage.width, pointsPerPixel, heightPts, equipment, nativePageWidth);
@@ -476,8 +486,10 @@ export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promi
 	}
 	const pages = pageNumbers ? pageNumbers.map((n) => note.pages[n - 1]) : note.pages;
 	const vectorInkPages = vectorInk ? prepareVectorInkPages(note, pageNumbers, upscale) : [];
-	const renderNote = vectorInk ? buildRenderNoteForVectorInk(note, vectorInkPages) : note;
+	const renderNote = vectorInk ? buildVectorInkBackgroundNote(note, vectorInkPages) : note;
+	const overlayNote = vectorInk ? buildRasterInkOverlayNote(note, vectorInkPages) : undefined;
 	const images = await toImage(renderNote, pageNumbers, { upscale });
+	const overlayImages = overlayNote ? await toImage(overlayNote, pageNumbers, { upscale }) : undefined;
 
 	const ctx = await createPdfContext({ fontBytes });
 	for (let i = 0; i < pages.length; i++) {
@@ -487,6 +499,7 @@ export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promi
 			dpi,
 			strokes: vip?.useVectorInk ? vip.strokes : undefined,
 			strokeStyles: vip?.useVectorInk ? vip.styles : undefined,
+			overlayImage: vip?.useVectorInk && parseDisabledInkRects(pages[i].DISABLE).length ? overlayImages?.[i] : undefined,
 			equipment: note.header.APPLY_EQUIPMENT,
 			nativePageWidth: note.pageWidth,
 		});

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -8,7 +8,9 @@ import {
 	VectorInkPrimitive,
 	buildVectorInkPrimitives,
 	prepareVectorInkPages,
-	buildRenderNoteForVectorInk,
+	buildVectorInkBackgroundNote,
+	buildRasterInkOverlayNote,
+	parseDisabledInkRects,
 } from './vector-ink.js';
 
 const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
@@ -166,6 +168,9 @@ export interface AddSvgPageOptions {
 	 * straight from its stroke's own already-upscaled points, so it needs no
 	 * separate scaling). */
 	strokeStyles?: StrokeStyle[];
+	/** A transparent bitmap-only ink overlay painted after vector strokes.
+	 * Used for text boxes/Digests that have no TOTALPATH representation. */
+	overlayImage?: Image | Uint8Array;
 	/** Device family this page's note was produced by
 	 * (`header.APPLY_EQUIPMENT`, e.g. 'A5X', 'N5', 'N6', 'A6X'), used to pick
 	 * the correct recognition-coordinate scale - see
@@ -203,10 +208,13 @@ export function addSvgPage(
 	pageHeight: number,
 	options: AddSvgPageOptions = {},
 ): string {
-	const { dpi, includeText = true, strokes, strokeStyles, equipment, nativePageWidth } = options;
+	const { dpi, includeText = true, strokes, strokeStyles, overlayImage, equipment, nativePageWidth } = options;
 
 	const pngBytes = image instanceof Uint8Array ? image : encodePng(image);
 	const base64 = encodeBase64(pngBytes);
+	const overlayBase64 = overlayImage
+		? encodeBase64(overlayImage instanceof Uint8Array ? overlayImage : encodePng(overlayImage))
+		: undefined;
 
 	const widthAttr = dpi ? `${pageWidth / dpi}in` : `${pageWidth}`;
 	const heightAttr = dpi ? `${pageHeight / dpi}in` : `${pageHeight}`;
@@ -219,8 +227,11 @@ export function addSvgPage(
 		`<svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" ` +
 		`width="${widthAttr}" height="${heightAttr}" viewBox="0 0 ${pageWidth} ${pageHeight}">` +
 		(defs ? `<defs>${defs}</defs>` : '') +
-		`<image x="0" y="0" width="${pageWidth}" height="${pageHeight}" xlink:href="data:image/png;base64,${base64}"/>` +
+		`<image data-page-background="true" x="0" y="0" width="${pageWidth}" height="${pageHeight}" xlink:href="data:image/png;base64,${base64}"/>` +
 		strokeElements +
+		(overlayBase64
+			? `<image data-raster-ink-overlay="true" x="0" y="0" width="${pageWidth}" height="${pageHeight}" xlink:href="data:image/png;base64,${overlayBase64}"/>`
+			: '') +
 		textElements +
 		`</svg>`
 	);
@@ -282,9 +293,11 @@ export async function toSvg(note: ISupernote, options: ToSvgOptions = {}): Promi
 	const pages = pageNumbers ? pageNumbers.map((n) => note.pages[n - 1]) : note.pages;
 
 	const vectorInkPages = vectorInk ? prepareVectorInkPages(note, pageNumbers, upscale) : [];
-	const renderNote = vectorInk ? buildRenderNoteForVectorInk(note, vectorInkPages) : note;
+	const renderNote = vectorInk ? buildVectorInkBackgroundNote(note, vectorInkPages) : note;
+	const overlayNote = vectorInk ? buildRasterInkOverlayNote(note, vectorInkPages) : undefined;
 
 	const images = await toImage(renderNote, pageNumbers, { upscale });
+	const overlayImages = overlayNote ? await toImage(overlayNote, pageNumbers, { upscale }) : undefined;
 
 	// Scale dpi along with the raster so widthAttr/heightAttr (pageWidth /
 	// dpi) come out the same physical size regardless of upscale.
@@ -300,6 +313,7 @@ export async function toSvg(note: ISupernote, options: ToSvgOptions = {}): Promi
 			includeText,
 			strokes,
 			strokeStyles,
+			overlayImage: vip?.useVectorInk && parseDisabledInkRects(page.DISABLE).length ? overlayImages?.[i] : undefined,
 			equipment: note.header.APPLY_EQUIPMENT,
 			nativePageWidth: note.pageWidth,
 		});

--- a/src/vector-ink.ts
+++ b/src/vector-ink.ts
@@ -260,6 +260,19 @@ function encodeRattaRuns(colors: Uint8Array): Uint8Array {
 	return new Uint8Array(encoded);
 }
 
+/** A valid all-transparent Ratta bitmap, used to give `toImage` a canvas
+ * for pages that have no bitmap-only overlay. */
+function transparentRattaBitmap(pageWidth: number, pageHeight: number): Uint8Array {
+	const pixelCount = pageWidth * pageHeight;
+	const output = new Uint8Array(Math.ceil(pixelCount / 128) * 2);
+	const background = new RattaRLEDecoder().encodedPalette.background;
+	for (let run = 0, start = 0; start < pixelCount; run++, start += 128) {
+		output[run * 2] = background;
+		output[run * 2 + 1] = Math.min(128, pixelCount - start) - 1;
+	}
+	return output;
+}
+
 /** Returns a Ratta bitmap retaining only pixels inside `rects`. The decoder's
  * palette translation supplies the reverse RGB-to-code lookup, so this keeps
  * the source layer's exact rendered colours rather than guessing a palette. */
@@ -294,8 +307,13 @@ function retainRasterInkInRects(
 /** Returns `page` with vectorizable ink layers cleared. `DISABLE` text-box
  * and Digest rectangles remain as a compact raster overlay because the file
  * has no vector representation for their contents. */
-export function withoutInkLayers(page: IPage, pageWidth: number, pageHeight: number): IPage {
-	const rasterInkRects = parseDisabledInkRects(page.DISABLE);
+export function withoutInkLayers(
+	page: IPage,
+	pageWidth: number,
+	pageHeight: number,
+	retainRasterInk = true,
+): IPage {
+	const rasterInkRects = retainRasterInk ? parseDisabledInkRects(page.DISABLE) : [];
 	const retain = (name: ILayerNames) =>
 		retainRasterInkInRects(page[name].bitmapBuffer, rasterInkRects, pageWidth, pageHeight);
 	return {
@@ -761,5 +779,41 @@ export function buildRenderNoteForVectorInk(note: ISupernote, vectorInkPages: Ve
 		pages: note.pages.map((page, i) =>
 			useVectorInkByPage.get(i + 1) ? withoutInkLayers(page, note.pageWidth, note.pageHeight) : page,
 		),
+	};
+}
+
+/** The template/background raster beneath vector ink. Raster-only text-box
+ * and Digest pixels are deliberately excluded here so callers can paint them
+ * over vector paths at their original layer order. */
+export function buildVectorInkBackgroundNote(note: ISupernote, vectorInkPages: VectorInkPage[]): ISupernote {
+	const useVectorInkByPage = new Map(vectorInkPages.map((p) => [p.pageNumber, p.useVectorInk]));
+	return {
+		...note,
+		pages: note.pages.map((page, i) =>
+			useVectorInkByPage.get(i + 1) ? withoutInkLayers(page, note.pageWidth, note.pageHeight, false) : page,
+		),
+	};
+}
+
+/** A transparent raster containing only bitmap-only text-box/Digest ink for
+ * vectorized pages. It must be painted after vector paths: some text lies on
+ * top of a decoded marker/highlighter stroke in the original layer stack. */
+export function buildRasterInkOverlayNote(note: ISupernote, vectorInkPages: VectorInkPage[]): ISupernote {
+	const useVectorInkByPage = new Map(vectorInkPages.map((p) => [p.pageNumber, p.useVectorInk]));
+	const transparentBitmap = transparentRattaBitmap(note.pageWidth, note.pageHeight);
+	const clear = (page: IPage): IPage => ({
+		...page,
+		MAINLAYER: { ...page.MAINLAYER, bitmapBuffer: transparentBitmap },
+		LAYER1: { ...page.LAYER1, bitmapBuffer: null },
+		LAYER2: { ...page.LAYER2, bitmapBuffer: null },
+		LAYER3: { ...page.LAYER3, bitmapBuffer: null },
+		BGLAYER: { ...page.BGLAYER, bitmapBuffer: null },
+	});
+	return {
+		...note,
+		pages: note.pages.map((page, i) => {
+			if (!useVectorInkByPage.get(i + 1) || parseDisabledInkRects(page.DISABLE).length === 0) return clear(page);
+			return { ...withoutInkLayers(page, note.pageWidth, note.pageHeight), BGLAYER: { ...page.BGLAYER, bitmapBuffer: null } };
+		}),
 	};
 }

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -554,6 +554,10 @@ describe("svg", () => {
 
       const [svg] = await toSvg(sn, { pageNumbers: [pageNumber], vectorInk: true })
       expect(svg).toContain("<path ")
+      // The bitmap overlay follows paths, preserving text painted over the
+      // page's decoded grey highlighter rather than covering it with vector ink.
+      expect(svg).toContain('data-raster-ink-overlay="true"')
+      expect(svg.indexOf("<path ")).toBeLessThan(svg.indexOf('data-raster-ink-overlay="true"'))
     }, { timeout: 30000 })
 
     test("erase-n6-20230015-horizontal-1270.note now crosses the coverage threshold and vectorizes (issue #56)", { timeout: 30000 }, async () => {


### PR DESCRIPTION
## Summary
- split vector-ink pages into a template/background image and a transparent bitmap-only text-box/Digest overlay
- paint the overlay after vector paths in SVG and PDF, preserving text over highlighter strokes
- keep the overlay in fixture-site ink-only SVG comparisons without leaking template background

## Validation
- `npm test`
- `npm run build:site`