### PR TITLE
feat: expose raster text overlays for worker renderers

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,26 @@ Note that only page rendering (`toImage`/`encodePng`) is parallelizable this way
 
 ```ts
 import {
-  SupernoteX, extractPdfPageData, prepareVectorInkPages, buildRenderNoteForVectorInk, createPdfContext, addPdfPage,
+  SupernoteX, extractPdfPageData, prepareVectorInkPages,
+  buildVectorInkBackgroundNote, buildRasterInkOverlayNote, createPdfContext, addPdfPage,
 } from 'supernote-typescript';
 
 const note = new SupernoteX(buffer);
 const pageNumbers = note.pages.map((_, i) => i + 1);
 const vectorInkPages = prepareVectorInkPages(note, pageNumbers, 1); // upscale 1: native resolution
 
-// buildRenderNoteForVectorInk() gives a copy of `note` with the bitmap ink
-// layers stripped from every page whose ink was replaced by vectors, so
-// the worker rasterizes only the background (BGLAYER) for those pages.
-const renderNote = buildRenderNoteForVectorInk(note, vectorInkPages);
+// Keep text boxes/Digests separate from the background. They are bitmap-only
+// ink, and must be painted after vector paths so a highlighter cannot cover
+// their glyphs.
+const backgroundNote = buildVectorInkBackgroundNote(note, vectorInkPages);
+const rasterOverlayNote = buildRasterInkOverlayNote(note, vectorInkPages);
 
 // Each page still goes through extractPdfPageData (or extractPageRenderData)
-// for the structured-clone-safe worker slice, but pulled from renderNote so
-// the ink layers are already gone where vectors replaced them.
-const pngBuffers = await Promise.all(
-  pageNumbers.map((n) => renderInWorker(extractPdfPageData(renderNote, n))),
-);
+// for the structured-clone-safe worker slice. Render both PNGs in the worker.
+const [pngBuffers, overlayPngBuffers] = await Promise.all([
+  Promise.all(pageNumbers.map((n) => renderInWorker(extractPdfPageData(backgroundNote, n)))),
+  Promise.all(pageNumbers.map((n) => renderInWorker(extractPdfPageData(rasterOverlayNote, n)))),
+]);
 
 const ctx = await createPdfContext();
 for (let i = 0; i < pageNumbers.length; i++) {
@@ -84,12 +86,13 @@ for (let i = 0; i < pageNumbers.length; i++) {
   await addPdfPage(ctx, note.pages[i], pngBuffers[i], {
     strokes: vip.useVectorInk ? vip.strokes : undefined,
     strokeStyles: vip.useVectorInk ? vip.styles : undefined,
+    overlayImage: vip.useVectorInk ? overlayPngBuffers[i] : undefined,
   });
 }
 const pdfBytes = await ctx.pdfDoc.save();
 ```
 
-`prepareVectorInkPages` decides, per page, whether the decoded strokes are trustworthy enough to replace the rasterized ink (it falls back to the raster for any page whose ink doesn't decode or decodes to nothing), so the only thing the caller does is pass the `strokes`/`strokeStyles` it produced through to `addPdfPage` for the pages where `useVectorInk` is true. Coordinates are in the same native page-pixel space as `toImage`'s raster at `upscale: 1`.
+`prepareVectorInkPages` decides, per page, whether the decoded strokes are trustworthy enough to replace the rasterized ink (it falls back to the raster for any page whose ink doesn't decode or decodes to nothing). The same background/overlay pair works with `addSvgPage`: pass the background PNG as `image`, vector `strokes`/`strokeStyles`, and the overlay PNG as `overlayImage`. Coordinates are in the same native page-pixel space as `toImage`'s raster at `upscale: 1`.
 
 ### Generating searchable SVGs
 

--- a/plans/textbox-bdom-spike.md
+++ b/plans/textbox-bdom-spike.md
@@ -1,0 +1,346 @@
+# Text-box / Digest structural extraction research
+
+## Question
+
+Can the text-box and Digest content in
+`textbox-n5-20260016-digest.note` be recovered as text, geometry, and styles
+from the embedded MyScript iink `RECOGNFILE`, or from another `.note` record,
+without reading the pixels in the affected regions?
+
+## Conclusion
+
+**Not from any structure identified in this fixture.** The strongest result of
+this investigation is that `RECOGNFILE` is a handwriting-recognition package,
+not the source model for the page's Supernote text boxes or Digest excerpt.
+Its BDOM text fields, BINK labels, and captured-ink geometry all describe the
+handwriting outside the page's `DISABLE` rectangles. They do not describe the
+typeset content inside those rectangles.
+
+The `.note` itself provides:
+
+- exact page-pixel rectangles in `DISABLE`;
+- the rendered pixels in the ordinary `MAINLAYER` Ratta-RLE bitmap;
+- a page-level `PAGETEXTBOX` flag;
+- for the Digest on page 5, an adjacent external-PDF `LINKO_` record containing
+  the source filename and source page number.
+
+It does **not** expose an identified text-box/Digest object record, original
+Unicode body, font/paragraph styles, or Digest source-selection range. Raster
+preservation therefore remains the only lossless, self-contained rendering
+path.
+
+## Fixture inventory
+
+Affected pages:
+
+| Page | `PAGETEXTBOX` | `DISABLE` (`x,y,w,h`) | Visible raster-only object |
+| --- | ---: | --- | --- |
+| 2 | 1 | `63,341,1735,616` | text box |
+| 4 | 1 | `67,425,1769,1859` | large text box |
+| 5 | 1 | `126,919,1622,174` | text box |
+| 5 | 1 | `84,195,1506,126` | Digest excerpt |
+
+Pages 2, 3, 4, 5, and 7 have `RECOGNFILE`; pages 3 and 7 have no text box and
+`PAGETEXTBOX=0`. Conversely, `PAGETEXTBOX` supplies no object count or object
+type. This establishes that recognition packages and text boxes are independent
+page features.
+
+The complete current page metadata was inventoried. Apart from normal layer,
+recognition, orientation, and page fields, the only relevant keys are
+`PAGETEXTBOX`, `DISABLE`, and (on recognized pages) `IDTABLE`. There is no
+`TEXTBOX`, `DIGEST`, object-list, or style-address key. The footer likewise
+contains only `PAGE*`, `TITLE_*`, `LINKO_*`, `STYLE_*`, `FILE_FEATURE`, and
+`DIRTY`; there is no Digest-specific footer group.
+
+On affected pages, both the handwriting and the typeset pixels are flattened
+into one ordinary `MAINLAYER` Ratta-RLE bitmap. `LAYERPATH`,
+`LAYERVECTORGRAPH`, and `LAYERRECOGN` are all `0`; there is no separate object
+layer or attachment to inspect.
+
+`IDTABLE` is not a text-object table. It has one entry per ink stroke sent to
+recognition (162, 38, and 51 entries on pages 2, 4, and 5), matching each page's
+BINK stroke count. `TOTALPATH` has 168, 41, and 54 records respectively because
+it also contains records not sent to MyScript. The ID-table payload contains
+base64-encoded IDs/opaque stroke identifiers, not text, bounds, or styles.
+
+## `RECOGNFILE` package
+
+`RECOGNFILE` is a length-prefixed ordinary ZIP archive. The inspected archives
+contain:
+
+```text
+meta.json
+rel.json
+index.bdom
+pages/<id>/meta.json
+pages/<id>/page.bdom
+pages/<id>/ink.bink
+pages/<id>/style.css
+```
+
+| Page | ZIP page ID | `page.bdom` bytes | `ink.bink` bytes |
+| --- | --- | ---: | ---: |
+| 2 | `qexziywj` | 30,209 | 457,521 |
+| 3 | `tmhvmsze` | 62,634 | 288,235 |
+| 4 | `yvlnearm` | 9,474 | 100,145 |
+| 5 | `hpmalcyl` | 14,723 | 43,255 |
+| 7 | `inpaexhl` | 87,595 | 791,701 |
+
+Package metadata identifies MyScript iink 3.0.3, document version 1.11,
+format 4.0, Android, locale `de_DE`, and page type `Raw Content`.
+`index.bdom` is only a document/page skeleton. `rel.json` has one generic
+`rectangle/1` object on every inspected page regardless of actual rectangle
+count, so it is not a text-box or Digest index.
+
+### BDOM text
+
+`page.bdom` is proprietary BDOM version 2. Its header is followed by a
+length-prefixed schema dictionary (216 entries in these packages), with names
+including `textField`, `textBlock`, `textLine`, `word`, `char`,
+`charCandidate`, bounds-related names, and generic style/layout names.
+Those names describe what the format *can* represent; they do not prove that a
+Supernote text-box object was serialized into this package.
+
+The understood subset identifies `textField` and `charCandidate` elements. A
+selected character candidate stores an inline UTF-8 label after a binary string
+token. Grouping candidates by field yields:
+
+| Page | BDOM text fields |
+| --- | --- |
+| 2 | `a.`; `=`; `M`; `aids`; `smishing → Sms-Phishing\nWuling (Whale-Phishing) → c- Level Phishing\nWishing → Phone-Phishing\nCEO-Fraud` |
+| 4 | `'odcast\nScale-Up 360°` |
+| 5 | `Test. [n P von Digest`; `Digest mit Link zum Buch` |
+
+The imperfect labels are the candidates stored by MyScript, not decoding
+errors. They are the same handwriting labels already present in
+`RECOGNTEXT` and in BINK `DIAGRAM` JSON.
+
+The object counts are also decisive:
+
+| Page | BDOM `textField` | BDOM `textBlock` | BINK text `DIAGRAM` | Raster-only regions |
+| --- | ---: | ---: | ---: | ---: |
+| 2 | 5 | 5 | 5 | 1 |
+| 4 | 1 | 1 | 1 | 1 |
+| 5 | 2 | 2 | 2 | 2 |
+
+Every BDOM field has a generated name such as `Text1785482311075360` that
+matches a BINK `DWContentFieldName` (`1/Text1785482311075360`). There are no
+additional text fields/blocks for the raster-only regions and no BDOM `image`
+elements. The BDOM `drawingField`/`shapeField` entries correspond to recognized
+free drawing and generic page structures, not the disabled rectangles.
+
+A raw contiguous-string search alone is insufficient for BDOM because its
+recognized prose is stored as candidate records, often one character at a
+time. The field/object inventory above avoids that false negative. Within the
+known object graph, however, the visible typeset body is absent.
+
+### BINK labels and geometry
+
+`ink.bink` contains:
+
+- captured X/Y/F/T ink channels (X and Y are declared in mm);
+- the captured pen strokes;
+- recognition-tree nodes such as `TEXT_STROKES`, `TEXT_LINE`, `TEXT_BLOCK`,
+  `WORD`, `CHAR`, and `TEXT`;
+- Supernote `DIAGRAM` JSON with `DWShape`, `DWContentFieldName`, `DWTagId`,
+  `DWLabel`, alignment, line-gap, and reflow flags.
+
+The BINK `DIAGRAM` labels exactly match the BDOM fields. Stroke-range attributes
+on each recognition node make geometry recoverable for that recognized
+handwriting. Converting the millimetre coordinates with the N5 recognition
+scale (approximately 11.9 page pixels/mm) gives these field extents:
+
+| Page | Recognized field | Approximate ink y-range (px) | Relevant `DISABLE` y-range (px) |
+| --- | --- | ---: | ---: |
+| 2 | four short fields near page top | 160–279 | 341–957 |
+| 2 | phishing notes | 1,055–1,483 | 341–957 |
+| 4 | `'odcast / Scale-Up 360°` | 114–384 | 425–2,284 |
+| 5 | `Digest mit Link zum Buch` | 16–95 | 195–321 |
+| 5 | `Test. [n P von Digest` | 800–915 | 919–1,093 |
+
+The separation is exact in intent, not merely a missing label: BINK has no
+captured strokes in the typeset regions. MyScript is recognizing the
+handwriting around each object, while `DISABLE` prevents those raster-only
+objects from participating in the vector/recognition ink path.
+
+Consequently, a fuller BINK decoder can provide character/word/line geometry
+for handwriting, but cannot recover the text-box or Digest body from this
+fixture.
+
+### Styles
+
+All five extracted `style.css` files are byte-identical (SHA-256
+`407fd2739d932773051b8e84532222109b4ff0190c08010b51ac3b57d75f787a`).
+They contain a large generic MyScript/Supernote stylesheet: default text rules,
+heading classes, named color classes, math/diagram styles, selection styles,
+and pen styles.
+
+For the affected pages, BINK references only generic recognition styles such
+as `defaultPenBrushStyle`, `black-color`, `pen-035`, and `raw-content` before
+its recognition tree. Its text `DIAGRAM` JSON has `DWAlignment: "Left"`,
+`DWLineGap: 0`, and recognition flags, but no text-box font or paragraph style.
+The BDOM object stream has no per-field `style` elements for the disabled
+objects.
+
+The CSS therefore describes renderer capabilities and recognized ink defaults;
+it is not evidence of the font/size/weight used by the visible Supernote text
+boxes. The text-box and Digest styles are only observable in their pixels in
+this fixture.
+
+## Digest-specific evidence
+
+Page 5 has one useful structural record adjacent to the upper disabled region:
+
+```text
+LINKRECT       913,321,759,70
+LINKFILE       /storage/emulated/0/Document/bok_978-3-658-51112-8.pdf
+OBJPAGE        61
+FULLTEXT       —bok_978-3-658-51112-8.pdf - Page 61
+FONTPATH       /system/fonts/DroidSansFallbackFull.ttf
+FONTSIZE       40.000000
+ITALIC         1
+```
+
+The disabled Digest rectangle ends at y=321 and the link starts at y=321.
+Together with the rendered page, this is strong evidence that the link is the
+Digest's source citation. It permits recovery of the source PDF path and page
+number, but:
+
+- no field explicitly types the disabled rectangle as `Digest`;
+- no metadata links that rectangle ID to the `LINKO_` record;
+- the source PDF is not embedded in the `.note`;
+- no source-text range, source-page rectangle, or extracted paragraph is
+  stored in the identified metadata;
+- `FONTPATH`/`FONTSIZE` style the displayed link label, not the excerpt.
+
+The second page-5 disabled region has no adjacent source link and is an
+ordinary text box. Spatial adjacency can therefore support a Digest heuristic,
+but not a general or authoritative object classifier.
+
+The standalone `digest-n5-20230015-test.mark` fixture does not fill the gap. It
+is a normal `markSN_FILE_VER_20230015` page/layer/TOTALPATH container for
+handwritten Digest notes. It has no `RECOGNFILE`, `DISABLE`, source-document
+record, or original Digest prose. A `.mark` file and an imported Digest excerpt
+inside a `.note` should not be assumed to share a structured text format.
+
+## Text searches and journal history
+
+Exact visible body phrases (for example `Belohnungen`, `Gutscheine`,
+`Goodies`, `Bonusspiele`, `Resilienz`, and the page-4 body prose) were searched
+in:
+
+- the raw `.note` as UTF-8, UTF-16LE/BE, and Latin-1;
+- every decompressed ZIP entry;
+- BINK printable payloads;
+- decoded BDOM text fields.
+
+Only the handwritten recognition labels and the external PDF link label are
+present structurally. The main-layer Ratta-RLE naturally contains glyph pixels,
+not searchable text.
+
+The note is append-only/journaled and contains historical page/footer snapshots.
+Those snapshots show page insertion/reordering and the same page-5 external
+link under earlier page numbers. They do not introduce a hidden Digest/text-box
+metadata group or plaintext body. This lowers, but cannot eliminate, the chance
+that an unreferenced proprietary block has been missed.
+
+## Confidence
+
+### High confidence
+
+- `RECOGNFILE` in this fixture models handwriting recognition, not the
+  disabled text-box/Digest objects.
+- BDOM selected text, BINK labels, and `RECOGNTEXT` are redundant recognition
+  representations of the same handwriting.
+- BINK geometry belongs entirely outside the affected `DISABLE` regions.
+- The original typeset bodies and their styles are absent from all identified
+  page/footer/ZIP structures.
+- `DISABLE` plus `MAINLAYER` pixels is the only self-contained, lossless render
+  source currently identified.
+- Page 5's `LINKO_` record recovers an external PDF filename and page 61.
+
+### Medium confidence
+
+- `PAGETEXTBOX` is a broad page flag and does not distinguish text boxes from
+  Digests.
+- The page-5 upper disabled rectangle and adjacent external link form one
+  Digest object/citation pair.
+- No recoverable high-level text-box model remains in the saved `.note` after
+  Supernote rasterizes the object.
+
+### Unknown / requires controlled fixtures
+
+- Whether another firmware/device version stores text-box source in a new key
+  or BDOM object type.
+- Whether an unparsed app-private block outside the current address graph
+  contains edit state.
+- Whether the device/Partner app keeps editable text in a separate database
+  not copied into the `.note`.
+- How `DISABLE` rectangle order relates to object creation or z-order.
+
+## Viable extraction approaches
+
+### 1. Preserve the raster overlay — production recommendation
+
+Keep the exact `DISABLE` pixels from `MAINLAYER` and paint them after vector
+ink. This is complete, offline, browser/Node-compatible, and retains the source
+font and layout. It is not selectable text.
+
+### 2. OCR each disabled rectangle
+
+The regions are exact and the content is typeset, so cropped OCR should be more
+accurate than whole-page handwriting recognition. Emit OCR text as a hidden
+search layer while continuing to display the original pixels. This does not
+recover authoritative source text or styles, but is the best self-contained
+searchability path.
+
+### 3. Resolve a Digest's external source
+
+When a disabled rectangle is spatially adjacent to a `LINKO_` citation, decode
+`LINKFILE` and `OBJPAGE`, obtain the external PDF, extract that source page's
+text, and match the rectangle OCR against it. This could correct OCR and recover
+Unicode accurately for page 5. It remains heuristic because the `.note` has no
+source selection range and usually does not carry the linked PDF.
+
+### 4. Expose recognition text/geometry separately
+
+BDOM candidate extraction or BINK tree parsing can expose recognized
+handwriting and its bounds. This is useful in its own right, but must be named
+and documented as recognition output—not text-box/Digest extraction. It should
+not replace `RECOGNTEXT` unless it demonstrably adds needed candidate data.
+
+### 5. MyScript SDK export — validation only for this question
+
+A licensed MyScript iink SDK can likely open the Raw Content package and export
+JIIX/SVG/text. Android artifacts are native/ABI-specific and
+`Engine.create()` is certificate-gated, so this is not a production Node/browser
+solution. More importantly, the package's object and geometry inventory shows
+that the disabled bodies were never included. SDK export is useful to validate
+the BDOM interpretation, but is unlikely to recover missing text-box content.
+
+### 6. Controlled differential corpus
+
+Before attempting more proprietary parsing, save successive copies after:
+
+1. adding a one-character text box;
+2. editing its text without moving it;
+3. changing font, size, color, alignment, and line spacing individually;
+4. moving/resizing it;
+5. inserting a Digest from a known PDF selection;
+6. moving or deleting the source citation;
+7. reopening and editing after a device restart.
+
+Compare all newly appended blocks, not only current footer addresses. If only
+`MAINLAYER`, `DISABLE`, thumbnails, and checksums change, structural extraction
+from `.note` can be treated as unavailable for that firmware. If a new address
+or object block appears, that controlled corpus will identify it far more
+reliably than further blind BDOM token decoding.
+
+## Recommendation
+
+Keep raster overlays as the rendering source. If selectable/searchable text is
+needed now, OCR only the `DISABLE` crops and retain the raster visually. Add an
+optional external-PDF matching path for Digest citations when the linked source
+is available. Treat BDOM/BINK extraction as handwriting-recognition support,
+not as a route to the missing text-box or Digest body, unless a new controlled
+fixture demonstrates that another firmware actually serializes those objects.

--- a/src/format.ts
+++ b/src/format.ts
@@ -12,6 +12,9 @@ export interface ILink {
 	LINKBITMAP: string;
 	LINKSTYLE: string;
 	LINKTIMESTAMP: string;
+	/** Font size of an on-device typeset link label. Zero for ordinary
+	 * handwritten/link-tag links. */
+	FONTSIZE: string;
 	/** Link rectangle coordinates (x, y, w, h as a comma-separated string). */
 	LINKRECT: string;
 	LINKRECTORI: string;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,12 @@ export type { ToPdfOptions, PdfContext, AddPdfPageOptions } from './pdf.js';
 export { toSvg, addSvgPage } from './svg.js';
 export type { ToSvgOptions, AddSvgPageOptions } from './svg.js';
 export type { StrokeStyle, VectorInkPrimitive, VectorInkPage } from './vector-ink.js';
-export { prepareVectorInkPages, buildRenderNoteForVectorInk } from './vector-ink.js';
+export {
+	prepareVectorInkPages,
+	buildRenderNoteForVectorInk,
+	buildVectorInkBackgroundNote,
+	buildRasterInkOverlayNote,
+} from './vector-ink.js';
 export { parseStrokes } from './strokes.js';
 export type { IStroke, IStrokePoint, StrokePen } from './strokes.js';
 export { SupernoteAtelier } from './atelier.js';

--- a/src/parsing.ts
+++ b/src/parsing.ts
@@ -718,6 +718,7 @@ export class SupernoteX implements ISupernote {
 			LINKBITMAP: '0',
 			LINKSTYLE: '0',
 			LINKTIMESTAMP: '0',
+			FONTSIZE: '0',
 			LINKRECT: '0',
 			LINKRECTORI: '0',
 			LINKPROTOCAL: 'RATTA_RLE',

--- a/src/pdf.ts
+++ b/src/pdf.ts
@@ -28,7 +28,7 @@ import {
 	prepareVectorInkPages,
 	buildVectorInkBackgroundNote,
 	buildRasterInkOverlayNote,
-	parseDisabledInkRects,
+	rasterInkRectsForPage,
 } from './vector-ink.js';
 
 // Recognized word bounding boxes are stored in raster-pixel units divided by
@@ -499,7 +499,7 @@ export async function toPdf(note: ISupernote, options: ToPdfOptions = {}): Promi
 			dpi,
 			strokes: vip?.useVectorInk ? vip.strokes : undefined,
 			strokeStyles: vip?.useVectorInk ? vip.styles : undefined,
-			overlayImage: vip?.useVectorInk && parseDisabledInkRects(pages[i].DISABLE).length ? overlayImages?.[i] : undefined,
+			overlayImage: vip?.useVectorInk && rasterInkRectsForPage(note, pageNumber).length ? overlayImages?.[i] : undefined,
 			equipment: note.header.APPLY_EQUIPMENT,
 			nativePageWidth: note.pageWidth,
 		});

--- a/src/svg.ts
+++ b/src/svg.ts
@@ -10,7 +10,7 @@ import {
 	prepareVectorInkPages,
 	buildVectorInkBackgroundNote,
 	buildRasterInkOverlayNote,
-	parseDisabledInkRects,
+	rasterInkRectsForPage,
 } from './vector-ink.js';
 
 const BASE64_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/';
@@ -313,7 +313,7 @@ export async function toSvg(note: ISupernote, options: ToSvgOptions = {}): Promi
 			includeText,
 			strokes,
 			strokeStyles,
-			overlayImage: vip?.useVectorInk && parseDisabledInkRects(page.DISABLE).length ? overlayImages?.[i] : undefined,
+			overlayImage: vip?.useVectorInk && rasterInkRectsForPage(note, pageNumber).length ? overlayImages?.[i] : undefined,
 			equipment: note.header.APPLY_EQUIPMENT,
 			nativePageWidth: note.pageWidth,
 		});

--- a/src/vector-ink.ts
+++ b/src/vector-ink.ts
@@ -241,6 +241,31 @@ export function parseDisabledInkRects(disable: string | undefined): RasterInkRec
 	});
 }
 
+/** Raster-only regions that must remain when page `pageNumber` is vectorized.
+ *
+ * `DISABLE` covers text boxes and Digest excerpts. A Digest's separately
+ * rendered PDF-link label sits immediately outside its `DISABLE` rectangle,
+ * but is likewise absent from `TOTALPATH`. Links with `FONTSIZE > 0` are
+ * those on-device typeset labels; ordinary link-tag rectangles use a zero
+ * font size and can enclose genuine vector handwriting, so must not be
+ * retained as a raster overlay. The first four characters of a `links` key
+ * are the 1-indexed source page number (see `_parseLinks`). */
+export function rasterInkRectsForPage(note: ISupernote, pageNumber: number): RasterInkRect[] {
+	const page = note.pages[pageNumber - 1];
+	if (!page) return [];
+	const linkRects = Object.entries(note.links).flatMap(([key, links]) => {
+		if (Number(key.slice(0, 4)) !== pageNumber) return [];
+		return links.flatMap((link) => {
+			if (!(Number(link.FONTSIZE) > 0)) return [];
+			const [x, y, width, height] = link.LINKRECT.split(',').map(Number);
+			return Number.isFinite(x) && Number.isFinite(y) && Number.isFinite(width) && Number.isFinite(height) && width > 0 && height > 0
+				? [{ x, y, width, height }]
+				: [];
+		});
+	});
+	return [...parseDisabledInkRects(page.DISABLE), ...linkRects];
+}
+
 function isInAnyRect(x: number, y: number, rects: RasterInkRect[]): boolean {
 	return rects.some((rect) => x >= rect.x && x < rect.x + rect.width && y >= rect.y && y < rect.y + rect.height);
 }
@@ -312,10 +337,11 @@ export function withoutInkLayers(
 	pageWidth: number,
 	pageHeight: number,
 	retainRasterInk = true,
+	rasterInkRects = parseDisabledInkRects(page.DISABLE),
 ): IPage {
-	const rasterInkRects = retainRasterInk ? parseDisabledInkRects(page.DISABLE) : [];
+	const retainedRects = retainRasterInk ? rasterInkRects : [];
 	const retain = (name: ILayerNames) =>
-		retainRasterInkInRects(page[name].bitmapBuffer, rasterInkRects, pageWidth, pageHeight);
+		retainRasterInkInRects(page[name].bitmapBuffer, retainedRects, pageWidth, pageHeight);
 	return {
 		...page,
 		MAINLAYER: { ...page.MAINLAYER, bitmapBuffer: retain('MAINLAYER') },
@@ -780,7 +806,9 @@ export function buildRenderNoteForVectorInk(note: ISupernote, vectorInkPages: Ve
 	return {
 		...note,
 		pages: note.pages.map((page, i) =>
-			useVectorInkByPage.get(i + 1) ? withoutInkLayers(page, note.pageWidth, note.pageHeight) : page,
+			useVectorInkByPage.get(i + 1)
+				? withoutInkLayers(page, note.pageWidth, note.pageHeight, true, rasterInkRectsForPage(note, i + 1))
+				: page,
 		),
 	};
 }
@@ -815,8 +843,12 @@ export function buildRasterInkOverlayNote(note: ISupernote, vectorInkPages: Vect
 	return {
 		...note,
 		pages: note.pages.map((page, i) => {
-			if (!useVectorInkByPage.get(i + 1) || parseDisabledInkRects(page.DISABLE).length === 0) return clear(page);
-			return { ...withoutInkLayers(page, note.pageWidth, note.pageHeight), BGLAYER: { ...page.BGLAYER, bitmapBuffer: null } };
+			const rasterInkRects = rasterInkRectsForPage(note, i + 1);
+			if (!useVectorInkByPage.get(i + 1) || rasterInkRects.length === 0) return clear(page);
+			return {
+				...withoutInkLayers(page, note.pageWidth, note.pageHeight, true, rasterInkRects),
+				BGLAYER: { ...page.BGLAYER, bitmapBuffer: null },
+			};
 		}),
 	};
 }

--- a/src/vector-ink.ts
+++ b/src/vector-ink.ts
@@ -770,8 +770,11 @@ export function prepareVectorInkPages(
 	return result;
 }
 
-/** Builds a copy of `note` with ink layers removed for every page where
- * `prepareVectorInkPages` decided vector ink should replace the raster ink. */
+/** Builds a copy of `note` with vectorizable ink layers removed for every
+ * page where `prepareVectorInkPages` decided vector ink should replace the
+ * raster ink. `DISABLE` text-box/Digest regions remain in this legacy
+ * single-raster result; use `buildVectorInkBackgroundNote` together with
+ * `buildRasterInkOverlayNote` when vector paths must remain beneath them. */
 export function buildRenderNoteForVectorInk(note: ISupernote, vectorInkPages: VectorInkPage[]): ISupernote {
 	const useVectorInkByPage = new Map(vectorInkPages.map((p) => [p.pageNumber, p.useVectorInk]));
 	return {

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -4,10 +4,10 @@ import { encodePng } from "image-js"
 import { toSvg, addSvgPage } from "../src/svg"
 import { parseStrokes } from "../src/strokes"
 import { recognitionCoordinateScale } from "../src/pdf"
-import { toImage } from "../src/conversion"
+import { RattaRLEDecoder, toImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
 import { buildRasterInkOverlayNote, buildVectorInkBackgroundNote } from "../src/index"
-import { buildRenderNoteForVectorInk, parseDisabledInkRects, prepareVectorInkPages } from "../src/vector-ink"
+import { buildRenderNoteForVectorInk, parseDisabledInkRects, prepareVectorInkPages, rasterInkRectsForPage } from "../src/vector-ink"
 import { describe, test, expect } from 'vitest'
 
 function readFileToUint8Array(filePath: string): Promise<Uint8Array> {
@@ -571,6 +571,42 @@ describe("svg", () => {
         overlayImage: rasterOverlay,
       })
       expect(workerSvg.indexOf("<path ")).toBeLessThan(workerSvg.indexOf('data-raster-ink-overlay="true"'))
+    }, { timeout: 30000 })
+
+    test("keeps a typeset PDF-link label just outside a Digest DISABLE rectangle", { timeout: 30000 }, async () => {
+      const sn = new SupernoteX(await readFileToUint8Array("textbox-n5-20260016-digest.note"))
+      const pageNumber = 5
+      // The Digest ends at y=321; its typeset source-PDF label occupies the
+      // adjacent LINKRECT. It has no TOTALPATH strokes, so retaining only
+      // DISABLE would lose it when the ink layer is vectorized.
+      expect(rasterInkRectsForPage(sn, pageNumber)).toEqual([
+        { x: 126, y: 919, width: 1622, height: 174 },
+        { x: 84, y: 195, width: 1506, height: 126 },
+        { x: 913, y: 321, width: 759, height: 70 },
+      ])
+
+      const vectorPages = prepareVectorInkPages(sn, [pageNumber], 1)
+      const retainedPage = buildRenderNoteForVectorInk(sn, vectorPages).pages[pageNumber - 1]
+      const decoder = new RattaRLEDecoder()
+      const source = decoder.decode(sn.pages[pageNumber - 1].MAINLAYER.bitmapBuffer!, sn.pageWidth, sn.pageHeight)
+      const retained = decoder.decode(retainedPage.MAINLAYER.bitmapBuffer!, sn.pageWidth, sn.pageHeight)
+      let differingBytes = 0
+      for (let row = 321; row < 391; row++) {
+        for (let column = 913; column < 1672; column++) {
+          const offset = (row * sn.pageWidth + column) * 4
+          // Ratta's transparent-white and transparent-black palette entries
+          // are visually identical; compare only rendered label pixels.
+          if (source[offset + 3] || retained[offset + 3]) {
+            for (let channel = 0; channel < 4; channel++) {
+              differingBytes += Number(source[offset + channel] !== retained[offset + channel])
+            }
+          }
+        }
+      }
+      expect(differingBytes).toBe(0)
+
+      const [svg] = await toSvg(sn, { pageNumbers: [pageNumber], vectorInk: true })
+      expect(svg).toContain('data-raster-ink-overlay="true"')
     }, { timeout: 30000 })
 
     test("erase-n6-20230015-horizontal-1270.note now crosses the coverage threshold and vectorizes (issue #56)", { timeout: 30000 }, async () => {

--- a/tests/svg.test.ts
+++ b/tests/svg.test.ts
@@ -6,6 +6,7 @@ import { parseStrokes } from "../src/strokes"
 import { recognitionCoordinateScale } from "../src/pdf"
 import { toImage } from "../src/conversion"
 import { SupernoteX } from "../src/parsing"
+import { buildRasterInkOverlayNote, buildVectorInkBackgroundNote } from "../src/index"
 import { buildRenderNoteForVectorInk, parseDisabledInkRects, prepareVectorInkPages } from "../src/vector-ink"
 import { describe, test, expect } from 'vitest'
 
@@ -558,6 +559,18 @@ describe("svg", () => {
       // page's decoded grey highlighter rather than covering it with vector ink.
       expect(svg).toContain('data-raster-ink-overlay="true"')
       expect(svg.indexOf("<path ")).toBeLessThan(svg.indexOf('data-raster-ink-overlay="true"'))
+
+      // Worker renderers can use the public pair of render notes with
+      // addSvgPage(), rather than clearing all ink from a page slice and
+      // losing the text-box/Digest bitmap entirely.
+      const [background] = await toImage(buildVectorInkBackgroundNote(sn, vectorPages), [pageNumber])
+      const [rasterOverlay] = await toImage(buildRasterInkOverlayNote(sn, vectorPages), [pageNumber])
+      const workerSvg = addSvgPage(sn.pages[pageNumber - 1], background, sn.pageWidth, sn.pageHeight, {
+        strokes: vectorPages[0].strokes,
+        strokeStyles: vectorPages[0].styles,
+        overlayImage: rasterOverlay,
+      })
+      expect(workerSvg.indexOf("<path ")).toBeLessThan(workerSvg.indexOf('data-raster-ink-overlay="true"'))
     }, { timeout: 30000 })
 
     test("erase-n6-20230015-horizontal-1270.note now crosses the coverage threshold and vectorizes (issue #56)", { timeout: 30000 }, async () => {


### PR DESCRIPTION
## Summary
- export the background and raster-overlay render-note builders for vector-ink consumers
- document the Worker pipeline that paints text-box/Digest bitmap overlays after SVG/PDF vector paths
- cover manual `addSvgPage` assembly with the public API

This lets consumers such as supernote-obsidian-plugin preserve `DISABLE` text-box/Digest regions instead of clearing them with the ordinary bitmap ink layers.

## Validation
- `npm test`
- `npm run build:site`
- `npm run lint`